### PR TITLE
Add `eager_open` option to containers

### DIFF
--- a/chainerio/container.py
+++ b/chainerio/container.py
@@ -7,10 +7,12 @@ from typing import Optional
 class Container(IO):
 
     def __init__(self, base_handler: IO, base: str,
-                 io_profiler: Optional[IOProfiler] = None, root: str = ""):
+                 io_profiler: Optional[IOProfiler] = None, root: str = "",
+                 eager_open=False):
         IO.__init__(self, io_profiler, root)
         self.base_handler = base_handler
         self.base = base
+        self.eager_open = eager_open
 
     def reset_base_handler(self, handler: IO) -> None:
         self.base_handler = handler

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -25,14 +25,17 @@ class ZipFileObject(FileObject):
 
 
 class ZipContainer(Container):
-    def __init__(self, base_handler, base):
-        Container.__init__(self, base_handler, base)
+    def __init__(self, base_handler, base, eager_open=False):
+        Container.__init__(self, base_handler, base, eager_open)
         self._check_zip_file_name(base)
 
         logger.info("using zip container for {}".format(base))
         self.zip_file_obj = None
         self.type = "zip"
         self.fileobj_class = ZipFileObject
+
+        if self.eager_open:
+            self._open_zip_file()
 
     def _check_zip_file_name(self, base):
         assert not "" == base and None is not base,\

--- a/chainerio/io.py
+++ b/chainerio/io.py
@@ -127,7 +127,7 @@ class IO(abc.ABC):
     # Python version to >=3.7
     def open_as_container(self, container_file: str) -> 'IO':
         container_class = self._get_container_handler(container_file)
-        return container_class(self, container_file)
+        return container_class(self, container_file, eager_open=True)
 
 
 # TODO(tianqi) need to be changed to annotaion when we bump the


### PR DESCRIPTION
This commit adds `eager_open` option to containers.
When set to True, the container_handler will open the underlying container
in __init__. This behaviour allows users to create a shared underlying objects
before spawning threads, and prevents threads from creating the objects
on their own.