### PR TITLE
Bugfix: Reflect default handler in global functions

### DIFF
--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -41,7 +41,7 @@ def list(path_or_prefix: Optional[str] = None,
     if None is path_or_prefix:
         path_or_prefix = ""
 
-    (handler, actual_path) = default_context.get_handler(path_or_prefix)
+    (handler, actual_path) = default_context.get_or_create_default_handler(path_or_prefix)
     return handler.list(actual_path, recursive)
 
 
@@ -57,7 +57,7 @@ def info() -> str:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, dummy_path) = default_context.get_handler()
+    (handler, dummy_path) = default_context.get_or_create_default_handler()
     return handler.info()
 
 
@@ -81,7 +81,7 @@ def open(file_path: str, mode: str = 'rb',
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_handler(file_path)
+    (handler, actual_path) = default_context.get_or_create_default_handler(file_path)
     return handler.open(
         actual_path, mode, buffering, encoding,
         errors, newline, closefd, opener)
@@ -212,7 +212,7 @@ def isdir(path: str) -> bool:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_handler(path)
+    (handler, actual_path) = default_context.get_or_create_default_handler(path)
     return handler.isdir(actual_path)
 
 
@@ -228,7 +228,7 @@ def mkdir(path: str, mode: int = 0o777, *,
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_handler(path)
+    (handler, actual_path) = default_context.get_or_create_default_handler(path)
     return handler.mkdir(actual_path, mode, dir_fd=dir_fd)
 
 
@@ -244,7 +244,7 @@ def makedirs(path: str, mode: int = 0o777,
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_handler(path)
+    (handler, actual_path) = default_context.get_or_create_default_handler(path)
     return handler.makedirs(actual_path, mode, exist_ok)
 
 
@@ -259,7 +259,7 @@ def exists(path: str) -> bool:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_handler(path)
+    (handler, actual_path) = default_context.get_or_create_default_handler(path)
     return handler.exists(actual_path)
 
 
@@ -275,8 +275,8 @@ def rename(src: str, dst: str) -> None:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler_src, actual_path_src) = default_context.get_handler(src)
-    (handler_dst, actual_path_dst) = default_context.get_handler(dst)
+    (handler_src, actual_path_src) = default_context.get_or_create_default_handler(src)
+    (handler_dst, actual_path_dst) = default_context.get_or_create_default_handler(dst)
     # TODO: containers are not supported here
     if type(handler_src) != type(handler_dst):
         raise NotImplementedError(
@@ -302,7 +302,7 @@ def remove(path: str, recursive: bool = False) -> None:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_handler(path)
+    (handler, actual_path) = default_context.get_or_create_default_handler(path)
     return handler.remove(actual_path, recursive)
 
 

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -41,7 +41,8 @@ def list(path_or_prefix: Optional[str] = None,
     if None is path_or_prefix:
         path_or_prefix = ""
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(path_or_prefix)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(path_or_prefix)
     return handler.list(actual_path, recursive)
 
 
@@ -81,7 +82,8 @@ def open(file_path: str, mode: str = 'rb',
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(file_path)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(file_path)
     return handler.open(
         actual_path, mode, buffering, encoding,
         errors, newline, closefd, opener)
@@ -212,7 +214,8 @@ def isdir(path: str) -> bool:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(path)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(path)
     return handler.isdir(actual_path)
 
 
@@ -228,7 +231,8 @@ def mkdir(path: str, mode: int = 0o777, *,
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(path)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(path)
     return handler.mkdir(actual_path, mode, dir_fd=dir_fd)
 
 
@@ -244,7 +248,8 @@ def makedirs(path: str, mode: int = 0o777,
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(path)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(path)
     return handler.makedirs(actual_path, mode, exist_ok)
 
 
@@ -259,7 +264,8 @@ def exists(path: str) -> bool:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(path)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(path)
     return handler.exists(actual_path)
 
 
@@ -275,8 +281,10 @@ def rename(src: str, dst: str) -> None:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler_src, actual_path_src) = default_context.get_or_create_default_handler(src)
-    (handler_dst, actual_path_dst) = default_context.get_or_create_default_handler(dst)
+    (handler_src, actual_path_src) = \
+        default_context.get_or_create_default_handler(src)
+    (handler_dst, actual_path_dst) = \
+        default_context.get_or_create_default_handler(dst)
     # TODO: containers are not supported here
     if type(handler_src) != type(handler_dst):
         raise NotImplementedError(
@@ -302,7 +310,8 @@ def remove(path: str, recursive: bool = False) -> None:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path) = default_context.get_or_create_default_handler(path)
+    (handler, actual_path) = \
+        default_context.get_or_create_default_handler(path)
     return handler.remove(actual_path, recursive)
 
 

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -1,4 +1,5 @@
 from chainerio._context import DefaultContext
+from chainerio.io import create_fs_handler
 from chainerio.version import __version__  # NOQA
 
 from chainerio.io import IO
@@ -198,9 +199,7 @@ def create_handler(scheme: str) -> IO:
     if not default_context.is_supported_scheme(scheme):
         raise ValueError("scheme {} is not supported".format(scheme))
 
-    (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(scheme)
-    return handler
+    return create_fs_handler(scheme)
 
 
 def isdir(path: str) -> bool:
@@ -213,8 +212,7 @@ def isdir(path: str) -> bool:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(path)
+    (handler, actual_path) = default_context.get_handler(path)
     return handler.isdir(actual_path)
 
 
@@ -230,8 +228,7 @@ def mkdir(path: str, mode: int = 0o777, *,
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(path)
+    (handler, actual_path) = default_context.get_handler(path)
     return handler.mkdir(actual_path, mode, dir_fd=dir_fd)
 
 
@@ -247,8 +244,7 @@ def makedirs(path: str, mode: int = 0o777,
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(path)
+    (handler, actual_path) = default_context.get_handler(path)
     return handler.makedirs(actual_path, mode, exist_ok)
 
 
@@ -263,8 +259,7 @@ def exists(path: str) -> bool:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(path)
+    (handler, actual_path) = default_context.get_handler(path)
     return handler.exists(actual_path)
 
 
@@ -280,15 +275,13 @@ def rename(src: str, dst: str) -> None:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler_src, actual_src, _is_URI1) = \
-        default_context.get_handler_by_name(src)
-    (handler_dst, actual_dst, _is_URI2) = \
-        default_context.get_handler_by_name(dst)
+    (handler_src, actual_path_src) = default_context.get_handler(src)
+    (handler_dst, actual_path_dst) = default_context.get_handler(dst)
     # TODO: containers are not supported here
     if type(handler_src) != type(handler_dst):
         raise NotImplementedError(
             "Moving between different systems is not supported")
-    handler_src.rename(actual_src, actual_dst)
+    handler_src.rename(actual_path_src, actual_path_dst)
 
 
 def remove(path: str, recursive: bool = False) -> None:
@@ -309,8 +302,7 @@ def remove(path: str, recursive: bool = False) -> None:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
-    (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(path)
+    (handler, actual_path) = default_context.get_handler(path)
     return handler.remove(actual_path, recursive)
 
 

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -13,7 +13,7 @@ class FileSystemDriverList(object):
         # as well as the patterns upon loading the chainerio module.
         self.scheme_list = ["hdfs", "posix"]
         self.posix_pattern = re.compile(r"file:\/\/(?P<path>.+)")
-        self.hdfs_pattern = re.compile(r"(?P<path>hdfs:\/\/.+)")
+        self.hdfs_pattern = re.compile(r"hdfs:\/\/(?P<path>.+)")
         self.pattern_list = {"hdfs": self.hdfs_pattern,
                              "posix": self.posix_pattern, }
         # this is a cache to store the handler for global context

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -8,7 +8,7 @@ from chainerio._typing import Union
 from typing import Tuple
 
 
-class FileSystemDriverList(object):
+class FileSystemHandlerList(object):
     def __init__(self):
         # TODO(tianqi): dynamically create this list
         # as well as the patterns upon loading the chainerio module.
@@ -55,7 +55,7 @@ class FileSystemDriverList(object):
 
 class DefaultContext(object):
     def __init__(self):
-        self._fs_handler_list = FileSystemDriverList()
+        self._fs_handler_list = FileSystemHandlerList()
 
         self._default_context = \
             self._fs_handler_list.get_or_create_cached_handler("posix")

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -18,40 +18,35 @@ class FileSystemDriverList(object):
         self.pattern_list = {"hdfs": self.hdfs_pattern,
                              "posix": self.posix_pattern, }
 
-    def _determine_fs_type(self, path: str) -> Tuple[str, str, bool]:
-        if None is not path:
-            for fs_type, pattern in self.pattern_list.items():
-                ret = pattern.match(path)
-                if ret:
-                    return (fs_type, ret.groupdict()["path"], True)
+    def format_path(self, path: str) -> Tuple[str, str, bool]:
+        if path in self.scheme_list:
+            # when the path is just a scheme
+            return (path, "", True)
+
+        for fs_type, pattern in self.pattern_list.items():
+            ret = pattern.match(path)
+            if ret:
+                return (fs_type, ret.groupdict()["path"], True)
 
         return ("posix", path, False)
 
-    def format_path(self, fs: IO, path: str) -> Tuple[str, bool]:
-        fs_type = fs.type
-        if fs_type in self.pattern_list.keys():
-            pattern = self.pattern_list[fs_type]
-            ret = pattern.match(path)
-            if ret:
-                return (ret.groupdict()["path"], True)
-            else:
-                return (path, False)
+    def _create_handler_from_path(self, path: str,
+                                  fs_type: str = None) -> Tuple[IO, str, bool]:
+        if fs_type is None:
+            (fs_type, actual_path, is_URI) = self.format_path(path)
         else:
-            return (path, False)
-
-    def get_handler_from_path(self, path: str) -> Tuple[IO, str, bool]:
-        (fs_type, actual_path, is_URI) = self._determine_fs_type(path)
+            actual_path = path
+            is_URI = False
 
         handler = create_fs_handler(fs_type)
         return (handler, actual_path, is_URI)
 
-    def get_handler_for_root(self,
-                             uri_or_handler_name: str) -> Tuple[IO, str, bool]:
+    def get_handler(self, uri_or_handler_name: str) -> Tuple[IO, str, bool]:
         if uri_or_handler_name in self.pattern_list.keys():
             return (create_fs_handler(uri_or_handler_name), "", False)
         else:
-            (new_handler, actual_path, is_URI) = self.get_handler_from_path(
-                uri_or_handler_name)
+            (new_handler, actual_path, is_URI) = \
+                self._create_handler_from_path(uri_or_handler_name)
             new_handler.root = actual_path
             return (new_handler, actual_path, is_URI)
 
@@ -62,55 +57,52 @@ class FileSystemDriverList(object):
 class DefaultContext(object):
     def __init__(self):
         self._fs_handler_list = FileSystemDriverList()
-        self._root = ""
 
         self._default_context = \
-            self._fs_handler_list.get_handler_for_root("posix")[0]
+            self._fs_handler_list.get_handler("posix")[0]
+
+        self._global_handler_cache = {}
 
     def set_root(self, uri_or_handler: Union[str, IO]) -> None:
-        # TODO(check) if root is directory
         if isinstance(uri_or_handler, IO):
             handler = uri_or_handler
-            self._root = ""
         else:
-            (handler, self._root, is_URI) = \
-                self.get_handler_by_name(uri_or_handler)
-        assert handler is not None
+            handler, path = self._get_handler_no_root(uri_or_handler)
+            handler.root = path
 
-        if self._root:
-            if not handler.isdir(self._root):
-                raise RuntimeError("the URI does not point to a directory")
+            if handler.root:
+                if not handler.isdir(handler.root):
+                    raise RuntimeError("""the URI '{}' does not
+                        point to a directory""".format(handler.root))
 
         self._default_context = handler
 
-    def get_handler(self, path: str = "") -> Tuple[IO, str]:
-        (handler, formatted_path,
-         is_URI) = self._fs_handler_list.get_handler_from_path(path)
+    def _get_handler_no_root(self, path: str = "") -> Tuple[IO, str]:
+        (fs_type, path, is_URI) = self._fs_handler_list.format_path(path)
 
         if not is_URI:
-            actual_path = os.path.join(self._root, formatted_path)
-            return (self._default_context, actual_path)
-        else:
-            return (handler, formatted_path)
-
-    def open_as_container(self, path: str) -> Container:
-        (handler, formatted_path,
-         is_URI) = self._fs_handler_list.get_handler_from_path(path)
-
-        if not is_URI:
-            actual_path = os.path.join(self._root, formatted_path)
             handler = self._default_context
         else:
-            actual_path = formatted_path
+            if fs_type in self._global_handler_cache:
+                # get handler from cache
+                handler = self._global_handler_cache[fs_type]
+            else:
+                # create a new handler
+                handler = create_fs_handler(fs_type)
+                self._global_handler_cache[fs_type] = handler
+        return (handler, path)
 
-        self._root = ""
+    def get_handler(self, path: str = "") -> Tuple[IO, str]:
+        handler, path = self._get_handler_no_root(path)
+        actual_path = os.path.join(handler.root, path)
+        return (handler, actual_path)
+
+    def open_as_container(self, path: str) -> Container:
+        (handler, actual_path) = self.get_handler(path)
         return handler.open_as_container(actual_path)
 
-    def get_handler_by_name(self, path: str) -> Tuple[IO, str, bool]:
-        return self._fs_handler_list.get_handler_for_root(path)
-
     def get_root_dir(self) -> str:
-        return self._root
+        return self._default_context.root
 
     def is_supported_scheme(self, scheme: str) -> bool:
         return self._fs_handler_list.is_supported_scheme(scheme)

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -31,24 +31,23 @@ class FileSystemDriverList(object):
         return ("posix", path, False)
 
     def _create_handler_from_path(self, path: str,
-                                  fs_type: str = None) -> Tuple[IO, str, bool]:
+                                  fs_type: str = None) -> Tuple[IO, str]:
         if fs_type is None:
-            (fs_type, actual_path, is_URI) = self.format_path(path)
+            (fs_type, actual_path, _) = self.format_path(path)
         else:
             actual_path = path
-            is_URI = False
 
         handler = create_fs_handler(fs_type)
-        return (handler, actual_path, is_URI)
+        return (handler, actual_path)
 
-    def get_handler(self, uri_or_handler_name: str) -> Tuple[IO, str, bool]:
+    def get_handler(self, uri_or_handler_name: str) -> Tuple[IO, str]:
         if uri_or_handler_name in self.pattern_list.keys():
-            return (create_fs_handler(uri_or_handler_name), "", False)
+            return (create_fs_handler(uri_or_handler_name), "")
         else:
-            (new_handler, actual_path, is_URI) = \
+            (new_handler, actual_path) = \
                 self._create_handler_from_path(uri_or_handler_name)
             new_handler.root = actual_path
-            return (new_handler, actual_path, is_URI)
+            return (new_handler, actual_path)
 
     def is_supported_scheme(self, scheme: str) -> bool:
         return scheme in self.scheme_list

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -34,18 +34,14 @@ class FileSystemHandlerList(object):
         return ("posix", path, False)
 
     def get_or_create_cached_handler(self, fs_type: str) -> IO:
-
-        self._handler_mt_lock.acquire()
-
-        if fs_type in self._handler_cache:
-            # get handler from cache
-            handler = self._handler_cache[fs_type]
-        else:
-            # create a new handler
-            handler = create_fs_handler(fs_type)
-            self._handler_cache[fs_type] = handler
-
-        self._handler_mt_lock.release()
+        with self._handler_mt_lock:
+            if fs_type in self._handler_cache:
+                # get handler from cache
+                handler = self._handler_cache[fs_type]
+            else:
+                # create a new handler
+                handler = create_fs_handler(fs_type)
+                self._handler_cache[fs_type] = handler
 
         return handler
 

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -61,12 +61,12 @@ class DefaultContext(object):
             handler = uri_or_handler
         else:
             handler, path = self.get_or_create_default_handler(uri_or_handler)
-            handler.root = path
 
-            if handler.root:
-                if not handler.isdir(handler.root):
+            if path:
+                if not handler.isdir(path):
                     raise RuntimeError("""the URI '{}' does not
-                        point to a directory""".format(handler.root))
+                        point to a directory""".format(path))
+            handler.root = path
 
         self._default_context = handler
 

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -33,7 +33,7 @@ class FileSystemHandlerList(object):
 
         return ("posix", path, False)
 
-    def get_or_create_cached_handler(self, fs_type: str) -> Tuple[IO]:
+    def get_or_create_cached_handler(self, fs_type: str) -> IO:
 
         self._handler_mt_lock.acquire()
 

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -98,6 +98,7 @@ class ZipContainer(Container):
             raise ValueError('Mode w and wb are not supported '
                              'only in Python < 3.6')
 
+        file_path = self.get_actual_path(file_path)
         file_path = os.path.normpath(file_path)
         self._open_zip_file(mode)
 
@@ -115,6 +116,7 @@ class ZipContainer(Container):
         return info_str
 
     def stat(self, path):
+        path = self.get_actual_path(path)
         path = os.path.normpath(path)
         self._open_zip_file()
         if path in self.zip_file_obj.namelist():
@@ -131,6 +133,8 @@ class ZipContainer(Container):
         return self.zip_file_obj.getinfo(actual_path)
 
     def list(self, path_or_prefix: str = "", recursive=False):
+        original_path = path_or_prefix
+        path_or_prefix = self.get_actual_path(path_or_prefix)
         self._open_zip_file()
 
         if path_or_prefix:
@@ -145,10 +149,10 @@ class ZipContainer(Container):
             given_dir_list = []
 
         if path_or_prefix:
-            if not self.exists(path_or_prefix):
+            if not self.exists(original_path):
                 raise FileNotFoundError(
                     "{} is not found".format(path_or_prefix))
-            elif not self.isdir(path_or_prefix):
+            elif not self.isdir(original_path):
                 raise NotADirectoryError(
                     "{} is not a directory".format(path_or_prefix))
 
@@ -205,6 +209,7 @@ class ZipContainer(Container):
         raise io.UnsupportedOperation("zip does not support makedirs")
 
     def exists(self, file_path: str):
+        file_path = self.get_actual_path(file_path)
         file_path = os.path.normpath(file_path)
         self._open_zip_file()
         namelist = self.zip_file_obj.namelist()

--- a/chainerio/filesystem.py
+++ b/chainerio/filesystem.py
@@ -1,7 +1,6 @@
 from chainerio.io import IO
 from chainerio.profiler import IOProfiler
 
-import os
 from chainerio._typing import Optional
 
 
@@ -10,6 +9,3 @@ class FileSystem(IO):
     def __init__(self, io_profiler: Optional[IOProfiler] = None,
                  root: str = ""):
         IO.__init__(self, io_profiler, root)
-
-    def get_actual_path(self, path: str) -> str:
-        return os.path.join(self.root, path)

--- a/chainerio/filesystems/posix.py
+++ b/chainerio/filesystems/posix.py
@@ -20,11 +20,13 @@ class PosixFileSystem(FileSystem):
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):
 
+        file_path = self.get_actual_path(file_path)
         return io.open(file_path, mode,
                        buffering, encoding, errors,
                        newline, closefd, opener)
 
     def list(self, path_or_prefix: str = None, recursive=False):
+        path_or_prefix = self.get_actual_path(path_or_prefix)
         if recursive:
             path_or_prefix = path_or_prefix.rstrip("/")
             # plus 1 to include the trailing slash
@@ -43,6 +45,7 @@ class PosixFileSystem(FileSystem):
                                                 file.path)
 
     def stat(self, path):
+        path = self.get_actual_path(path)
         return os.stat(path)
 
     def close(self):
@@ -55,21 +58,30 @@ class PosixFileSystem(FileSystem):
         pass
 
     def isdir(self, file_path: str):
+        file_path = self.get_actual_path(file_path)
         return os.path.isdir(file_path)
 
     def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
+        file_path = self.get_actual_path(file_path)
         return os.mkdir(file_path, mode, *args, dir_fd=None)
 
     def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
+        file_path = self.get_actual_path(file_path)
         return os.makedirs(file_path, mode, exist_ok)
 
     def exists(self, file_path: str):
+        file_path = self.get_actual_path(file_path)
         return os.path.exists(file_path)
 
     def rename(self, src, dst):
+        src = self.get_actual_path(src)
+        dst = self.get_actual_path(dst)
+
         return os.rename(src, dst)
 
     def remove(self, file_path: str, recursive=False):
+        file_path = self.get_actual_path(file_path)
+
         if recursive:
             return shutil.rmtree(file_path)
         if os.path.isdir(file_path):

--- a/chainerio/io.py
+++ b/chainerio/io.py
@@ -5,6 +5,7 @@ from importlib import import_module
 from chainerio.profiler import IOProfiler
 
 from chainerio._typing import Optional
+import os
 from typing import Type, Callable, Iterator, Any
 from types import TracebackType
 
@@ -95,6 +96,14 @@ class IO(abc.ABC):
     @root.setter
     def root(self, root: str) -> None:
         self._root = root
+
+    def get_actual_path(self, path: str) -> str:
+        if path is None:
+            return self.root
+        elif path.startswith('/'):
+            # we only change the relative paths
+            return path
+        return os.path.join(self.root, path)
 
     @abstractmethod
     def info(self) -> str:

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -120,6 +120,24 @@ class TestZipHandler(unittest.TestCase):
         self.tmpdir.cleanup()
         chainerio.remove(self.zip_file_path)
 
+    def test_root(self):
+        with self.fs_handler.open_as_container(
+                os.path.abspath(self.zip_file_path)) as handler:
+            # set root
+            handler.root = self.dir_name2
+            # open with root
+            with handler.open(self.zipped_file_name, "r") as f:
+                self.assertEqual(self.test_string, f.read())
+
+            # list with root
+            self.assertEqual(list(handler.list()), [self.zipped_file_name])
+            # stat with root
+            self.assertIsNotNone(handler.stat(self.zipped_file_name))
+            # exists with root
+            self.assertTrue(handler.exists(self.zipped_file_name))
+            # isdir with root
+            self.assertFalse(handler.isdir(self.zipped_file_name))
+
     def test_read_bytes(self):
         with self.fs_handler.open_as_container(
                 os.path.abspath(self.zip_file_path)) as handler:

--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -37,6 +37,58 @@ class TestHdfsHandler(unittest.TestCase):
         self.fs = "hdfs"
         self.tmpfile_name = "tmpfile.txt"
 
+    def test_root(self):
+        with chainerio.create_handler(self.fs) as handler:
+            # prepare the tmpfile
+            tmpdir = "testdir"
+
+            handler.mkdir(tmpdir)
+            try:
+                self.assertTrue(handler.exists(tmpdir))
+
+                testfile_name = "testfile"
+                testfile_path = os.path.join(tmpdir, testfile_name)
+                with handler.open(testfile_path, "w") as f:
+                    f.write(self.test_string)
+
+                self.assertTrue(handler.exists(testfile_path))
+
+                # set root
+                handler.root = os.path.join(tmpdir)
+                # open with root
+                with handler.open(testfile_name, "r") as f:
+                    self.assertEqual(self.test_string, f.read())
+
+                # list with root
+                self.assertEqual(list(handler.list()), [testfile_name])
+                # stat with root
+                self.assertIsNotNone(handler.stat(testfile_name))
+                # exits with root
+                self.assertTrue(handler.exists(testfile_name))
+                # exits with root
+                new_testfile_name = "new_test_filename"
+                handler.rename(testfile_name, new_testfile_name)
+                self.assertFalse(handler.exists(testfile_name))
+                self.assertTrue(handler.exists(new_testfile_name))
+                # mkdir with root
+                mkdir_name = "mkdir"
+                handler.mkdir(mkdir_name)
+                self.assertTrue(handler.exists(mkdir_name))
+                # # mkdir with root
+                # TODO(tianqi): has a bug with makedirs,
+                # will fix it in another PR
+                # mkdirs_name = "mkdirs/dirs"
+                # handler.makedirs(mkdirs_name)
+                # self.assertTrue(handler.exists(mkdirs_name))
+                # isdir with root
+                self.assertTrue(handler.isdir(mkdir_name))
+                # remove with root
+                handler.remove(mkdir_name)
+                self.assertFalse(handler.exists(mkdir_name))
+            finally:
+                handler.root = ""
+                handler.remove(tmpdir, True)
+
     def test_read_bytes(self):
 
         with chainerio.create_handler(self.fs) as handler:

--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -41,9 +41,10 @@ class TestHdfsHandler(unittest.TestCase):
         with chainerio.create_handler(self.fs) as handler:
             # prepare the tmpfile
             tmpdir = "testdir"
+            original_root = handler.root
 
-            handler.mkdir(tmpdir)
             try:
+                handler.mkdir(tmpdir)
                 self.assertTrue(handler.exists(tmpdir))
 
                 testfile_name = "testfile"
@@ -86,7 +87,8 @@ class TestHdfsHandler(unittest.TestCase):
                 handler.remove(mkdir_name)
                 self.assertFalse(handler.exists(mkdir_name))
             finally:
-                handler.root = ""
+                # set back the root to delete the tmpdir
+                handler.root = original_root
                 handler.remove(tmpdir, True)
 
     def test_read_bytes(self):

--- a/tests/filesystem_tests/test_posix_handler.py
+++ b/tests/filesystem_tests/test_posix_handler.py
@@ -16,6 +16,48 @@ class TestPosixHandler(unittest.TestCase):
         self.test_string_bytes = self.test_string_str.encode("utf-8")
         self.fs = "posix"
 
+    def test_root(self):
+        with chainerio.create_handler(self.fs) as handler:
+            # prepare the tmpfile
+            with tempfile.TemporaryDirectory() as tmpdir:
+                testfile_name = "testfile"
+                testfile_path = os.path.join(tmpdir, testfile_name)
+                with handler.open(testfile_path, "w") as f:
+                    f.write(self.test_string_str)
+
+                self.assertTrue(os.path.exists(testfile_path))
+
+                # set root
+                handler.root = tmpdir
+                # open with root
+                with handler.open(testfile_name, "r") as f:
+                    self.assertEqual(self.test_string_str, f.read())
+
+                # list with root
+                self.assertEqual(list(handler.list()), [testfile_name])
+                # stat with root
+                self.assertIsNotNone(handler.stat(testfile_name))
+                # exits with root
+                self.assertTrue(handler.exists(testfile_name))
+                # exits with root
+                new_testfile_name = "new_test_filename"
+                handler.rename(testfile_name, new_testfile_name)
+                self.assertFalse(handler.exists(testfile_name))
+                self.assertTrue(handler.exists(new_testfile_name))
+                # mkdir with root
+                mkdir_name = "mkdir"
+                handler.mkdir(mkdir_name)
+                self.assertTrue(handler.exists(mkdir_name))
+                # mkdir with root
+                mkdirs_name = "mkdirs/dirs"
+                handler.makedirs(mkdirs_name)
+                self.assertTrue(handler.exists(mkdirs_name))
+                # isdir with root
+                self.assertTrue(handler.isdir(mkdir_name))
+                # remove with root
+                handler.remove(mkdir_name)
+                self.assertFalse(handler.exists(mkdir_name))
+
     def test_read_string(self):
 
         with chainerio.create_handler(self.fs) as handler:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -138,46 +138,46 @@ class TestContext(unittest.TestCase):
     def test_root_fs_override(self):
         from pyarrow import hdfs
 
-        hdfs_tmpdir = "tmpdir_hdfs"
-        hdfs_tmpfile = os.path.join(hdfs_tmpdir, "tmpfile_hdfs")
-        hdfs_tmpnested_dir = os.path.join(hdfs_tmpdir, "nesteddir_hdfs")
-        hdfs_tmpfile_renamed = os.path.join(hdfs_tmpdir, "renamed_file")
-        hdfs_file_string = "this is a test string for hdfs"
+        tmpdir = "tmpdir"
+        tmpfile = os.path.join(tmpdir, "tmpfile")
+        tmpnested_dir = os.path.join(tmpdir, "nesteddir")
+        tmpfile_renamed = os.path.join(tmpdir, "renamed")
+        file_string = "this is a test string"
 
         chainerio.set_root("hdfs")
 
         conn = hdfs.connect()
-        chainerio.mkdir(hdfs_tmpdir)
-        chainerio.makedirs(hdfs_tmpnested_dir)
+        chainerio.mkdir(tmpdir)
+        chainerio.makedirs(tmpnested_dir)
 
-        with conn.open(hdfs_tmpfile, "wb") as f:
-            f.write(hdfs_file_string.encode('utf-8'))
+        with conn.open(tmpfile, "wb") as f:
+            f.write(file_string.encode('utf-8'))
 
-        with chainerio.open(hdfs_tmpfile, "r") as fp:
-            self.assertEqual(fp.read(), hdfs_file_string)
+        with chainerio.open(tmpfile, "r") as fp:
+            self.assertEqual(fp.read(), file_string)
 
         # override with full URI
         with open(__file__, "r") as my_script:
             with chainerio.open("file://" + __file__, "r") as fp:
                 self.assertEqual(fp.read(), my_script.read())
 
-        with chainerio.open(hdfs_tmpfile, "r") as fp:
-            self.assertEqual(fp.read(), hdfs_file_string)
+        with chainerio.open(tmpfile, "r") as fp:
+            self.assertEqual(fp.read(), file_string)
 
-        self.assertEqual(chainerio.isdir(hdfs_tmpnested_dir), True)
+        self.assertEqual(chainerio.isdir(tmpnested_dir), True)
 
-        self.assertEqual(sorted(list(chainerio.list(hdfs_tmpdir))),
-                         sorted(["tmpfile_hdfs", "nesteddir_hdfs"]))
+        self.assertEqual(sorted(list(chainerio.list(tmpdir))),
+                         sorted(["tmpfile", "nesteddir"]))
 
-        self.assertEqual(chainerio.exists(hdfs_tmpfile), True)
-        self.assertEqual(chainerio.exists(hdfs_tmpfile_renamed), False)
+        self.assertEqual(chainerio.exists(tmpfile), True)
+        self.assertEqual(chainerio.exists(tmpfile_renamed), False)
 
-        chainerio.rename(hdfs_tmpfile, hdfs_tmpfile_renamed)
-        self.assertEqual(chainerio.exists(hdfs_tmpfile), False)
-        self.assertEqual(chainerio.exists(hdfs_tmpfile_renamed), True)
+        chainerio.rename(tmpfile, tmpfile_renamed)
+        self.assertEqual(chainerio.exists(tmpfile), False)
+        self.assertEqual(chainerio.exists(tmpfile_renamed), True)
 
-        chainerio.remove(hdfs_tmpdir, recursive=True)
-        self.assertEqual(chainerio.exists(hdfs_tmpdir), False)
+        chainerio.remove(tmpdir, recursive=True)
+        self.assertEqual(chainerio.exists(tmpdir), False)
         conn.close()
 
         chainerio.set_root("posix")


### PR DESCRIPTION
This PR fixes a bug that some of the global functions do not refer
to the default handler.
This PR closes #98 