### PR TITLE
replace 'github.com/chainer/pfio' with 'github.com/pfnet/pfio'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ learning training with batteries included. It supports
 Installation
 
 ```shell
-$ git clone https://github.com/chainer/pfio.git
+$ git clone https://github.com/pfnet/pfio.git
 $ cd pfio
 $ pip install .
 ```

--- a/pfio/__init__.py
+++ b/pfio/__init__.py
@@ -180,7 +180,7 @@ def create_handler(scheme: str) -> IO:
     1. posix
     2. hdfs
 
-    See `scheme <https://github.com/chainer/pfio/blob/master/\
+    See `scheme <https://github.com/pfnet/pfio/blob/master/\
             docs/source/design.rst#uri-expression-of-file-paths>`_
     for more details.
 

--- a/pfio/_typing.py
+++ b/pfio/_typing.py
@@ -3,7 +3,7 @@ import typing
 
 
 # workaround for old CPython bug
-# https://github.com/chainer/pfio/issues/28
+# https://github.com/pfnet/pfio/issues/28
 if sys.version_info < (3, 5, 3):
     class DummyOptional(object):
 

--- a/pfio/io.py
+++ b/pfio/io.py
@@ -316,7 +316,7 @@ class IO(abc.ABC):
 
         This function opens a container, e.g. zip, instead of a regular file.
         For more details about the container, please refer to the `design \
-                <https://github.com/chainer/pfio/blob/master/docs/\
+                <https://github.com/pfnet/pfio/blob/master/docs/\
                 source/design.rst#containers>`_
 
         Works when the current handler is also a container: nested container.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     description='PFN IO library',
     author='Tianqi Xu, Kota Uenishi',
     author_email='tianqi@preferred.jp, kota@preferred.jp',
-    url='http://github.com/chainer/pfio',
+    url='http://github.com/pfnet/pfio',
     classifiers=[
         'Development Status :: 3 - Alpha',
 


### PR DESCRIPTION
I noticed that `github.com/chainer/pfio` remains in several places while the repository has moved to `github.com/pfnet/pfio`.