### PR TITLE
MultiprocessFileCache for efficient and easy cache with pytorch dataloader (num_workers>0)

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -56,6 +56,9 @@ Cache API
 .. autoclass:: FileCache
    :members: preserve, preload
 
+.. autoclass:: MultiprocessFileCache
+   :members: preserve, preload
+
 Chainer Extensions API
 ----------------------
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -47,6 +47,81 @@ Cache API
 
 .. currentmodule:: pfio.cache
 
+PFIO provides experimental cache API to improve performance of
+repetitive access to the data collection.
+
+.. admonition:: Example
+
+   Here let us suppose we have a file that includes a list of paths to images.
+   ::
+
+       /path/to/image1.jpg
+       /path/to/image2.jpg
+       ...
+       /path/to/imageN.jpg
+
+   The PyTorch Dataset class with using :class:`~NaiveCache` as an example
+   can be implemented as follows.
+   ::
+
+       from pfio.cache import NaiveCache
+
+
+       class MyDataset(torch.utils.data.Dataset):
+           def __init__(self, image_paths):
+               self.paths = image_paths
+               self.cache = NaiveCache(len(image_paths), do_pickle=True)
+
+           def __len__(self):
+               return len(self.paths)
+
+           def _read_image(self, i):
+               return cv2.imread(self.paths[i]).transpose(2, 0, 1)
+
+           def __getitem__(self, i):
+               x = self.cache.get_and_cache(i, self._read_image)
+
+               # This is equivalent
+               # x = self.cache.get(i)
+               # if not x:
+               #     x = cv2.imread(self.paths[i]).transpose(2, 0, 1)
+               #     self.cache.put(i, x)
+
+               return torch.Tensor(x)
+
+   By calling ``get_and_cache`` of the cache in ``__getitem__`` method,
+   it will check if the data for the specified index is already cached.
+   If there already is, it reads the data from the cache and return,
+   otherwise it calls the actual data loading function, add it to the cache,
+   and return it.
+   Therefore load the data from the storage only when necessary,
+   which is at the first access to each data.
+
+PFIO cache API provides :class:`~NaiveCache`, :class:`~FileCache`and
+:class:`~MultiprocessFileCache`.
+They all share the same core idea and interface.
+The difference is how to manage the cached data.
+
+The :class:`~NaiveCache` keeps everything in memory,
+making it virtually zero overhead.
+The cache capacity is limited by the memory size,
+thus it would not be suitable for large-scale datasets.
+
+The :class:`~FileCache` and the :class:`~MultiprocessFileCache` both
+store the cached data in a filesystem.
+The :class:`~FileCache` is designed for single-process data load.
+In case of parallelized data loading, which is relatively common in
+deep learning workloads, consider using :class:`~MultiprocessFileCache`.
+
+Also, these file-based caches support cache data persistency.
+Once the cache is completely built, we can keep them as files by calling
+:func:``FileCache.preserve``, and we can recover the cache
+from the preserved files by calling :func:``FileCache.preload``.
+This is useful when we want to reuse the cache already built in a previous workload.
+
+Currently deletion of a data from cache is not supported.
+
+
 .. autoclass:: Cache
    :members:
 

--- a/pfio/__init__.py
+++ b/pfio/__init__.py
@@ -6,6 +6,8 @@ from pfio.io import IO
 from pfio._typing import Optional, Union
 from typing import Iterator, Any, Callable, Type
 
+import pfio.cache  # NOQA
+
 
 _DEFAULT_CONTEXT = DefaultContext()
 

--- a/pfio/cache/__init__.py
+++ b/pfio/cache/__init__.py
@@ -61,3 +61,4 @@ class Cache(six.with_metaclass(abc.ABCMeta)):
 
 from pfio.cache.naive import NaiveCache  # NOQA
 from pfio.cache.file_cache import FileCache  # NOQA
+from pfio.cache.multiprocess_file_cache import MultiprocessFileCache  # NOQA

--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -293,6 +293,9 @@ class FileCache(cache.Cache):
         to the cache.  ``name`` is the prefix of the persistent
         files.
 
+        The preserved cache can also be preloaded by
+        :class:`~MultiprocessFileCache`.
+
         .. note:: This feature is experimental.
 
         '''

--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -100,6 +100,8 @@ class FileCache(cache.Cache):
         dir (str): The path to the directory to place cache data in
             case home directory is not backed by fast storage device.
 
+        verbose (bool):
+            Print detailed logs of the cache.
     '''
 
     def __init__(self, length, multithread_safe=False, do_pickle=False,

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -151,6 +151,9 @@ class MultiprocessFileCache(cache.Cache):
         dir (str): The path to the directory to place cache data in
             case home directory is not backed by fast storage device.
 
+        verbose (bool):
+            Print detailed logs of the cache.
+
     '''  # NOQA
 
     def __init__(self, length, do_pickle=False,
@@ -172,6 +175,10 @@ class MultiprocessFileCache(cache.Cache):
         self.data_file = _NoOpenNamedTemporaryFile(self.dir, self._master_pid)
         self.index_file = _NoOpenNamedTemporaryFile(self.dir, self._master_pid)
         index_fd = os.open(self.index_file.name, os.O_RDWR)
+
+        if self.verbose:
+            print('created index file:', self.index_file.name)
+            print('created data file:', self.data_file.name)
 
         try:
             fcntl.flock(index_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -358,6 +358,8 @@ class MultiprocessFileCache(cache.Cache):
         to the cache.  ``name`` is the prefix of the persistent
         files.
 
+        The preserved cache can also be preloaded by :class:`~FileCache`.
+
         Be noted that ``preserve()`` can be called only by the master process
         i.e., the process where ``__init__()`` is called,
         in order to prevent inconsistency.

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -342,6 +342,9 @@ class MultiprocessFileCache(cache.Cache):
 
         '''
 
+        if self._master_pid != os.getpid():
+            raise RuntimeError("Cannot preserve a cache in a worker process")
+
         index_file = os.path.join(self.dir, '{}.cachei'.format(name))
         data_file = os.path.join(self.dir, '{}.cached'.format(name))
 

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -77,7 +77,7 @@ class MultiprocessFileCache(cache.Cache):
         except OSError as ose:
             # Lock acquisition error -> No problem, since other worker
             # should be already working on it
-            if ose.errno not in (errno.EACCESS, errno.EAGAIN):
+            if ose.errno not in (errno.EACCES, errno.EAGAIN):
                 raise
         finally:
             fcntl.flock(index_fd, fcntl.LOCK_UN)

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -55,23 +55,21 @@ class _DummyTemporaryFile(object):
 
 
 class MultiprocessFileCache(cache.Cache):
-    '''Multiprocess-safe cache system with local filesystem
+    '''The Multiprocess-safe cache system on a local filesystem
 
-    Stores cache data in local temporary files, created in
-    ``~/.pfio/cache`` by default. Cache data is
-    automatically deleted after the object is collected. When this
-    object is not correctly closed, (e.g., the process killed by
-    SIGTERM), the cache remains after the death of process.
+    Stores cache data in local temporary files, created in ``~/.pfio/cache``
+    by default. It automatically deletes the cache data after the object is
+    collected. When this object is not correctly closed (e.g., the process
+    killed by SIGKILL), the cache remains after the process's death.
 
     This class supports handling a cache from multiple processes.
     A MultiprocessFileCache object can be handed over to another process
     through the pickle. Calling ``get`` and ``put`` in each process will
-    look into the same cache files which are created by the initializer.
-    The temporary cache files will persist until the MultiprocessFileCache
-    object is destroyed in the original process it is created.
-    This means that even after the worker processes are destroyed,
-    the MultiprocessFileCache object can be passed to another processes,
-    with the cache files remain accessible.
+    look into the same cache files with flock-based locking. The temporary
+    cache files will persist as long as the MultiprocessFileCache object is
+    alive in the original process that creates it.
+    Therefore, even after destroying the worker processes,
+    the MultiprocessFileCache object can still be passed to another process.
 
     Arguments:
         length (int): Length of the cache array.

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -1,0 +1,117 @@
+import fcntl
+import os
+import tempfile
+import warnings
+
+from multiprocessing import RawArray, Value
+
+from pfio import cache
+from pfio.cache.file_cache import _DEFAULT_CACHE_PATH
+import pickle
+
+
+class MultiprocessFileCache(cache.Cache):
+
+    def __init__(self, length, do_pickle=False,
+                 dir=None, verbose=False):
+        self.length = length
+        self.do_pickle = do_pickle
+        assert self.length > 0
+
+        if dir is None:
+            self.dir = _DEFAULT_CACHE_PATH
+        else:
+            self.dir = dir
+        os.makedirs(self.dir, exist_ok=True)
+
+        self.closed = False
+        self.offsets = RawArray('i', [-1] * self.length)
+        self.lengths = RawArray('i', [0] * self.length)
+        _, self.data_file = tempfile.mkstemp(dir=self.dir)
+
+    def __len__(self):
+        return self.length
+
+    def get(self, i):
+        if self.closed:
+            return
+        data = self._get(i)
+        if self.do_pickle and data:
+            data = pickle.loads(data)
+        return data
+
+    def _get(self, i):
+        assert i >= 0 and i < self.length
+        o = self.offsets[i]
+        l = self.lengths[i]
+        if l <= 0 or o < 0:
+            return None
+
+        with open(self.data_file, 'rb') as f:
+            fcntl.fcntl(f.fileno(), fcntl.LOCK_SH)
+            f.seek(o)
+            data = f.read(l)
+            fcntl.fcntl(f.fileno(), fcntl.LOCK_UN)
+            assert len(data) == l
+            return data
+
+    def put(self, i, data):
+        try:
+            if self.do_pickle:
+                data = pickle.dumps(data)
+            return self._put(i, data)
+
+        except OSError as ose:
+            # Disk full (ENOSPC) possibly by cache; just warn and keep running
+            if ose.errno == 28:
+                warnings.warn(ose.strerror, RuntimeWarning)
+                return False
+            else:
+                raise ose
+
+    def _put(self, i, data):
+        if self.closed:
+            return
+        assert i >= 0 and i < self.length
+
+        o = self.offsets[i]
+        l = self.lengths[i]
+        if 0 < l or 0 <= o:
+            return False
+
+        fd = os.open(self.data_file, os.O_APPEND | os.O_WRONLY)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        with os.fdopen(fd, 'ab') as f:
+            pos = f.tell()
+            assert f.write(data) == len(data)
+            f.flush()
+
+            self.offsets[i] = pos
+            self.lengths[i] = len(data)
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+            return True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        if not self.closed:
+            self.closed = True
+            # https://github.com/python/cpython/blob/3.8/Lib/tempfile.py#L437
+            os.unlink(self.data_file)
+            self.data_file = None
+
+    @property
+    def multiprocess_safe(self) -> bool:
+        return True
+
+    @property
+    def multithread_safe(self) -> bool:
+        return True

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -12,13 +12,40 @@ import pickle
 
 
 class MultiprocessFileCache(cache.Cache):
+    '''Multiprocess-safe cache system with local filesystem
+
+    Stores cache data in local temporary files, created in
+    ``~/.pfio/cache`` by default. Cache data is
+    automatically deleted after the object is collected. When this
+    object is not correctly closed, (e.g., the process killed by
+    SIGTERM), the cache remains after the death of process.
+
+    This class supports handling a cache from multiple processes.
+    A MultiprocessFileCache object can be handed over to another process
+    through the pickle. Calling ``get`` and ``put`` in each process will
+    look into the same cache files which are created by the initializer.
+    The temporary cache files will persist until the MultiprocessFileCache
+    object is destroyed in the original process it is created.
+    This means that even after the worker processes are destroyed,
+    the MultiprocessFileCache object can be passed to another processes,
+    with the cache files remain accessible.
+
+    Arguments:
+        length (int): Length of the cache array.
+
+        do_pickle (bool):
+            Do automatic pickle and unpickle inside the cache.
+
+        dir (str): The path to the directory to place cache data in
+            case home directory is not backed by fast storage device.
+
+    '''
 
     def __init__(self, length, do_pickle=False,
-                 dir=None, verbose=False,
-                 index_cache_file=None, data_cache_file=None,
-                 cleanup=True):
+                 dir=None, verbose=False):
         self.length = length
         self.do_pickle = do_pickle
+        self.verbose = verbose
         assert self.length > 0
 
         if dir is None:
@@ -27,19 +54,11 @@ class MultiprocessFileCache(cache.Cache):
             self.dir = dir
         os.makedirs(self.dir, exist_ok=True)
 
-        self.cleanup = cleanup
         self.closed = False
-        if not data_cache_file:
-            _, self.data_file = tempfile.mkstemp(dir=self.dir)
-        else:
-            self.data_file = data_cache_file
-
-        if not index_cache_file:
-            index_fd, self.index_file = tempfile.mkstemp(dir=self.dir)
-        else:
-            self.index_file = index_cache_file
-            flag = os.O_WRONLY | os.O_TRUNC | os.O_CREAT
-            index_fd = os.open(index_cache_file, flag)
+        self._frozen = False
+        self._master_pid = os.getpid()
+        _, self.data_file = tempfile.mkstemp(dir=self.dir)
+        index_fd, self.index_file = tempfile.mkstemp(dir=self.dir)
 
         try:
             fcntl.flock(index_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -55,26 +74,24 @@ class MultiprocessFileCache(cache.Cache):
 
             # Clear data file
             os.close(os.open(self.data_file, os.O_WRONLY | os.O_TRUNC))
-
-            fcntl.flock(index_fd, fcntl.LOCK_UN)
         except OSError as ose:
             # Lock acquisition error -> No problem, since other worker
             # should be already working on it
             if ose.errno not in (errno.EACCESS, errno.EAGAIN):
                 raise
-
-    def get_offsets(self):
-        fd = os.open(self.index_file, os.O_RDONLY)
-        offsets = []
-        for i in range(self.length):
-            offset = self.buflen * i
-            buf = os.pread(fd, self.buflen, offset)
-            (o, l) = unpack('Qq', buf)
-            offsets.append(o)
-        return offsets
+        finally:
+            fcntl.flock(index_fd, fcntl.LOCK_UN)
 
     def __len__(self):
         return self.length
+
+    @property
+    def multiprocess_safe(self) -> bool:
+        return True
+
+    @property
+    def multithread_safe(self) -> bool:
+        return True
 
     def get(self, i):
         if self.closed:
@@ -105,6 +122,9 @@ class MultiprocessFileCache(cache.Cache):
         return data
 
     def put(self, i, data):
+        if self._frozen:
+            return
+
         try:
             if self.do_pickle:
                 data = pickle.dumps(data)
@@ -163,22 +183,70 @@ class MultiprocessFileCache(cache.Cache):
         try:
             unlink(fn)
         except FileNotFoundError:
-            # Other worker may have already deleted it
+            # Another worker may have already deleted it
             pass
 
     def close(self):
         if not self.closed:
-            self.closed = True
-            if self.cleanup:
+            if os.getpid() == self._master_pid:
                 self._deleter(self.data_file)
                 self._deleter(self.index_file)
+            self.closed = True
             self.data_file = None
             self.index_file = None
 
-    @property
-    def multiprocess_safe(self) -> bool:
-        return True
+    def preload(self, name):
+        '''Load the cache saved by ``preserve()``
 
-    @property
-    def multithread_safe(self) -> bool:
-        return True
+        After loading the files, no data can be added to the cache.
+        ``name`` is the prefix of the persistent files.
+
+        .. note:: This feature is experimental.
+
+        '''
+        if self._frozen:
+            return
+
+        # Overwrite the current cache by the specified cache file.
+        # This is needed to prevent the specified cache files are deleted when
+        # the cache object is destroyed.
+        ld_index_file = os.path.join(self.dir, '{}.cachei'.format(name))
+        ld_data_file = os.path.join(self.dir, '{}.cached'.format(name))
+        if any(not os.path.exists(p) for p in (ld_index_file, ld_data_file)):
+            raise ValueError('Specified cache "{}" not found in {}'
+                             .format(name, self.dir))
+
+        self._deleter(self.data_file)
+        self._deleter(self.index_file)
+        os.link(ld_index_file, self.index_file)
+        os.link(ld_data_file, self.data_file)
+        self._frozen = True
+
+    def preserve(self, name):
+        '''Preserve the cache as persistent files on the disk
+
+        Once the cache is preserved, cache files will not be removed
+        at cache close. To read data from preserved files, use
+        ``preload()`` method. After preservation, no data can be added
+        to the cache.  ``name`` is the prefix of the persistent
+        files.
+
+        .. note:: This feature is experimental.
+
+        '''
+
+        index_file = os.path.join(self.dir, '{}.cachei'.format(name))
+        data_file = os.path.join(self.dir, '{}.cached'.format(name))
+        fd = os.open(self.index_file, os.O_RDONLY)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            os.link(self.index_file, index_file)
+            os.link(self.data_file, data_file)
+
+        except OSError as ose:
+            # Lock acquisition error -> No problem, since other worker
+            # should be already working on it
+            if ose.errno not in (errno.EACCESS, errno.EAGAIN):
+                raise
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -88,7 +88,7 @@ class MultiprocessFileCache(cache.Cache):
         assert 0 <= i < self.length
 
         offset = self.buflen * i
-        index_fd = os.open(self.index_file, os.O_RDONLY)
+        index_fd = os.open(self.index_file, os.O_RDONLY | os.O_NOATIME)
         fcntl.flock(index_fd, fcntl.LOCK_SH)
         buf = os.pread(index_fd, self.buflen, offset)
         (o, l) = unpack('Qq', buf)
@@ -96,7 +96,7 @@ class MultiprocessFileCache(cache.Cache):
             fcntl.flock(index_fd, fcntl.LOCK_UN)
             return None
 
-        data_fd = os.open(self.data_file, os.O_RDONLY)
+        data_fd = os.open(self.data_file, os.O_RDONLY | os.O_NOATIME)
         with os.fdopen(data_fd, 'rb') as f:
             f.seek(o)
             data = f.read(l)

--- a/tests/cache_tests/test_file_cache.py
+++ b/tests/cache_tests/test_file_cache.py
@@ -1,4 +1,5 @@
 from pfio.cache import FileCache
+from pfio.cache import MultiprocessFileCache
 import os
 import tempfile
 
@@ -47,6 +48,27 @@ def test_preservation():
 
         # Imitating a new process, fresh load
         cache2 = FileCache(10, dir=d, do_pickle=True)
+
+        cache2.preload('preserved')
+        for i in range(10):
+            assert str(i) == cache2.get(i)
+
+
+def test_preservation_interoperability():
+    with tempfile.TemporaryDirectory() as d:
+        cache = FileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        cache.preserve('preserved')
+
+        for i in range(10):
+            assert str(i) == cache.get(i)
+
+        cache.close()
+
+        cache2 = MultiprocessFileCache(10, dir=d, do_pickle=True)
 
         cache2.preload('preserved')
         for i in range(10):

--- a/tests/cache_tests/test_multiprocess_file_cache.py
+++ b/tests/cache_tests/test_multiprocess_file_cache.py
@@ -4,6 +4,8 @@ import os
 import pickle
 import tempfile
 
+import numpy as np
+
 import pytest
 
 
@@ -49,6 +51,41 @@ def test_cleanup_subprocess():
         cache.close()
 
         assert len(os.listdir(d)) == 0
+
+
+def test_multiprocess_consistency():
+    # Condition: 32k samples (8k*4bytes each) cached by 64 workers.
+    # Each sample is an array of repeated sample index.
+    # ie. k-th sample is np.array([k, k, k, ..., k], dtype=np.int32)
+    # 32 worker processes simultaneously create such data and insert them into
+    # a single cache, and we check if the data can be correctly recovered.
+    n_workers = 32
+    n_samples_per_worker = 1024
+    sample_size = 8192
+
+    def child(cache, worker_idx):
+        for i in range(n_samples_per_worker):
+            sample_idx = worker_idx * n_samples_per_worker + i
+            data = np.array([sample_idx] * sample_size, dtype=np.int32)
+            cache.put(sample_idx, data)
+
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(n_samples_per_worker * n_workers,
+                                      dir=d, do_pickle=True)
+
+        # Add tons of data into the cache in parallel
+        ps = [multiprocessing.Process(target=child, args=(cache, worker_idx))
+              for worker_idx in range(n_workers)]
+        for i, p in enumerate(ps):
+            p.start()
+        for i, p in enumerate(ps):
+            p.join()
+
+        # Get each sample from the cache and check the content
+        for sample_idx in range(n_workers * n_samples_per_worker):
+            data = cache.get(sample_idx)
+            expected = np.array([sample_idx] * sample_size, dtype=np.int32)
+            assert (data == expected).all()
 
 
 def test_preservation():

--- a/tests/cache_tests/test_multiprocess_file_cache.py
+++ b/tests/cache_tests/test_multiprocess_file_cache.py
@@ -1,3 +1,4 @@
+from pfio.cache import FileCache
 from pfio.cache import MultiprocessFileCache
 import multiprocessing
 import os
@@ -111,6 +112,26 @@ def test_preservation():
         # No temporary cache file should remain,
         # and the preserved cache should be kept.
         assert os.listdir(d) == ['preserved.cached', 'preserved.cachei']
+
+
+def test_preservation_interoperability():
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        cache.preserve('preserved')
+
+        cache.close()
+
+        cache2 = FileCache(10, dir=d, do_pickle=True)
+
+        cache2.preload('preserved')
+        for i in range(10):
+            assert str(i) == cache2.get(i)
+
+        cache2.close()
 
 
 def test_preservation_error_already_exists():

--- a/tests/cache_tests/test_multiprocess_file_cache.py
+++ b/tests/cache_tests/test_multiprocess_file_cache.py
@@ -1,0 +1,130 @@
+from pfio.cache import MultiprocessFileCache
+import multiprocessing
+import os
+import pickle
+import tempfile
+
+import pytest
+
+
+def test_pickable():
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+        try:
+            pickle.dumps(cache)
+        except TypeError:
+            pytest.fail("Unpicklabe Pickle fails")
+
+        cache.close()
+
+
+def test_cleanup():
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        assert len(os.listdir(d)) == 2
+
+        cache.close()
+
+        assert len(os.listdir(d)) == 0
+
+
+def test_cleanup_subprocess():
+    def child(c):
+        c.close()
+
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+        p = multiprocessing.Process(target=child, args=(cache,))
+        p.start()
+        p.join()
+
+        # Calling close in the subprocess should not
+        # delete the cache files
+        assert len(os.listdir(d)) == 2
+
+        cache.close()
+
+        assert len(os.listdir(d)) == 0
+
+
+def test_preservation():
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        cache.preserve('preserved')
+
+        cache.close()
+
+        # Imitating a new process, fresh load
+        cache2 = MultiprocessFileCache(10, dir=d, do_pickle=True)
+
+        cache2.preload('preserved')
+        for i in range(10):
+            assert str(i) == cache2.get(i)
+
+        cache2.close()
+
+        # No temporary cache file should remain,
+        # and the preserved cache should be kept.
+        assert os.listdir(d) == ['preserved.cached', 'preserved.cachei']
+
+
+def test_preservation_error_already_exists():
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        cache.preserve('preserved')
+
+        with pytest.raises(ValueError):
+            cache.preserve('preserved')
+
+        cache.close()
+
+
+def test_preload_error_not_found():
+    with tempfile.TemporaryDirectory() as d:
+        cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
+
+        with pytest.raises(ValueError):
+            cache.preload('preserved')
+
+        cache.close()
+
+
+def test_enospc(monkeypatch):
+    def mock_pread(_fd, _buf, _offset):
+        ose = OSError(28, "No space left on device")
+        raise ose
+
+    with monkeypatch.context() as m:
+        m.setattr(os, 'pread', mock_pread)
+
+        with MultiprocessFileCache(10) as cache:
+            i = 2
+            with pytest.warns(RuntimeWarning):
+                cache.put(i, str(i))
+
+
+def test_enoent(monkeypatch):
+    def mock_pread(_fd, _buf, _offset):
+        ose = OSError(2, "No such file or directory")
+        raise ose
+
+    with monkeypatch.context() as m:
+        m.setattr(os, 'pread', mock_pread)
+
+        with MultiprocessFileCache(10) as cache:
+
+            with pytest.raises(OSError):
+
+                cache.put(4, str(4))


### PR DESCRIPTION
In case we combine pfio (+HDFS) with PyTorch DataLoader (num_workers>0), due to the following
reasons that are complexly related each other, I noticed that it is hard to make efficient/effective use of pfio FileCache easily.
* With HDFS, setting num_workers>0 is necessary for practical data loading performance
* The current pfio FileCache supports therad-safety but cannot be process-safe
* Currently PyTorch DataLoader is designed to destroy all the worker processes at the end of each epoch

https://github.com/pytorch/pytorch/pull/35795 would solve part of the problems, but being difficult for efficiently setting higher `num_workers` will remain unsolved.

After serious considerations, I figured out that implementing multi-process safe file cache is the simplest way to overcome this issue.
This PR is the introduction of the `MultiprocessFileCache` which imitates the interface and behavior of the existing `FileCache`.

(* modified from the initial implementation)
The new `MultiprocessFileCache` is supposed to be initialized in a single master process and then distributed to its child processes through pickle.
All of these cloned object handle the same cache file(s) created by the master process. The `MultiprocessFileCache` does not keep file descriptors or file objects of the cache files as in the current `FileCache`, but instead it only keeps the filenames. Every time it reads/writes the cache it opens them. This provides process safety.
Cache files remain undeleted as long as the `MultiprocessFileCache` in the *master* process alives, no matter if `MultiprocessFileCache` is destroyed earlier in the *child* process by explicit call of `close`, `exit` nor GC. When the object is destroyed in the master, caches are made sure to be destroyed. This behavior is necessary to prevent the cache is lost in every epoch, when using with PyTorch DataLoader.

A micro-banchmark showed approximately 2x speedup (loading ImageNet zipped val images (including jpeg decode) with `num_workers=16`, cpu=24 setting) in my internal environment.