### PR TITLE
Remove `krbticket`

### DIFF
--- a/pfio/filesystems/hdfs.py
+++ b/pfio/filesystems/hdfs.py
@@ -1,7 +1,6 @@
 from pfio.filesystem import FileSystem
 from pfio.io import FileStat
 from pfio.io import open_wrapper
-from krbticket import KrbTicket, SingleProcessKrbTicketUpdater
 
 import subprocess
 import re
@@ -150,14 +149,6 @@ class HdfsFileSystem(FileSystem):
     def _create_connection(self):
         if None is self.connection:
             logger.debug('creating connection')
-
-            # Updater automatically let kinit take ``KRB5_KTNAME``
-            # variable. If /etc/krb5.keytab doesn't exist, krbticket
-            # tries to update the ticket with ``kinit -R`` as much as
-            # possible.
-            self.ticket = KrbTicket.get_or_init(
-                self.username, updater_class=SingleProcessKrbTicketUpdater)
-            self.ticket.updater_start()
 
             connection = hdfs.connect()
             assert connection is not None

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.5",
-    install_requires=['krbticket>=1.0.5', 'pyarrow'],
+    install_requires=['pyarrow'],
     include_package_data=True,
     zip_safe=False,
 


### PR DESCRIPTION
This PR removes the `krbticket`. The `krbticket` was introduced to
update the kerberos ticket. As the `Hadoop` handles the ticket update
internally, we have decided to remove the `krbticket` and rely on the
`Hadoop` update mechanism.