### PR TITLE
Test documentation with python 3.7

### DIFF
--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -5,6 +5,9 @@ source /root/.bash_docker
 pyenv global 3.5.2 3.6.8 3.7.2
 tox && :
 tox_status=$?
+
+# test doc, needs python >= 3.6
+pyenv global 3.7.2
 pip install .[doc]
 cd docs && make html && :
 sphinx_status=$?

--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -123,7 +123,7 @@ class TestHdfsHandler(unittest.TestCase):
     def test_get_principal_name_from_klist(self):
         username = 'fake_user!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
         service = 'fake_service!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
-        correct_out = 'Ticket cache: FILE:/tmp/krb5cc_sdfa\nDefault principal: {}@{}\nValid starting       Expires              Service principal\n10/01/2019 12:44:18  10/08/2019 12:44:14   krbtgt/service@service\nrenew until 10/22/2019 15:04:20'.format(username, service) # NOQA
+        correct_out = 'Ticket cache: FILE:/tmp/krb5cc_sdfa\nDefault principal: {}@{}\nValid starting       Expires              Service principal\n10/01/2019 12:44:18  10/08/2019 12:44:14   krbtgt/service@service\nrenew until 10/22/2019 15:04:20'.format(username, service)  # NOQA
         self.assertEqual(username,
                          _parse_principal_name_from_klist(correct_out))
 


### PR DESCRIPTION
numpy >= 1.14 is used when building the documentation. It requires
python >= 3.6, which causes an error in the current CI. This PR fixes
the python version to 3.7 when testing the documentation.
For more details: https://ci.preferred.jp/chainerio/60833/