### PR TITLE
Cache index error

### DIFF
--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -170,7 +170,10 @@ class FileCache(cache.Cache):
         return data
 
     def _get(self, i):
-        assert i >= 0 and i < self.length
+        if i < 0 or self.length <= i:
+            raise IndexError("index {} out of range ([0, {}])"
+                             .format(i, self.length - 1))
+
         offset = self.buflen * i
         with self.lock.rdlock():
             buf = os.pread(self.indexfp.fileno(), self.buflen, offset)
@@ -200,7 +203,10 @@ class FileCache(cache.Cache):
     def _put(self, i, data):
         if self.closed:
             return
-        assert i >= 0 and i < self.length
+        if i < 0 or self.length <= i:
+            raise IndexError("index {} out of range ([0, {}])"
+                             .format(i, self.length - 1))
+
         offset = self.buflen * i
 
         with self.lock.wrlock():

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -207,7 +207,9 @@ class MultiprocessFileCache(cache.Cache):
             self.data_fd = os.open(self.data_file.name, os.O_RDWR)
 
     def _get(self, i):
-        assert 0 <= i < self.length
+        if i < 0 or self.length <= i:
+            raise IndexError("index {} out of range ([0, {}])"
+                             .format(i, self.length - 1))
 
         self._open_fds()
         offset = self.buflen * i
@@ -243,7 +245,9 @@ class MultiprocessFileCache(cache.Cache):
     def _put(self, i, data):
         if self.closed:
             return
-        assert 0 <= i < self.length
+        if i < 0 or self.length <= i:
+            raise IndexError("index {} out of range ([0, {}])"
+                             .format(i, self.length - 1))
 
         self._open_fds()
         index_ofst = self.buflen * i

--- a/tests/cache_tests/test_cache.py
+++ b/tests/cache_tests/test_cache.py
@@ -95,3 +95,53 @@ def test_cache_blob(test_class, mt_safe, length):
         data = cache.get(i)
         assert data is not None
         assert _getbin(i) == data
+
+
+def test_index_range_naive():
+    l = 10
+    cache = make_cache(NaiveCache, True, False, l)
+
+    # Index check for Put
+
+    cache.put(-1, pickle.dumps(9 ** 2))
+
+    for i in range(l - 1):
+        cache.put(i, pickle.dumps(i * 2))
+
+    with pytest.raises(IndexError):
+        cache.put(l, pickle.dumps('too large'))
+
+    # Index check for Get
+
+    with pytest.raises(IndexError):
+        cache.get(l)
+
+    assert pickle.loads(cache.get(-1)) == 9 ** 2
+    assert pickle.loads(cache.get(9)) == 9 ** 2
+
+
+@pytest.mark.parametrize("test_class", [FileCache, MultiprocessFileCache])
+def test_index_range_get(test_class):
+    l = 10
+    cache = make_cache(test_class, True, False, l)
+
+    for i in range(l):
+        cache.put(i, pickle.dumps(i * 2))
+
+    with pytest.raises(IndexError):
+        cache.get(-1)
+
+    with pytest.raises(IndexError):
+        cache.get(l)
+
+
+@pytest.mark.parametrize("test_class", [FileCache, MultiprocessFileCache])
+def test_index_range_put(test_class):
+    l = 10
+    cache = make_cache(test_class, True, False, l)
+
+    with pytest.raises(IndexError):
+        cache.put(-1, pickle.dumps('negative'))
+
+    with pytest.raises(IndexError):
+        cache.put(l, pickle.dumps('too large'))


### PR DESCRIPTION
Currently, pfio caches check the index of `get` and `put` by the following ways.
- FileCache/MultiprocessFileCache: simple assertion (0 <= i < N)
- NaiveCache: IndexError (i < N; based on the list inside)

In PyTorch, when iterating over a Dataset _without DataLoader_ (which is actually rare case), it doesn't respect the length (`__len__`) of the dataset but instead detects the termination by either IndexError or StopIteration.

```python
>>> import torch
>>>
>>> class Foo1(torch.utils.data.Dataset):
...     def __len__(self):
...         return 3
...     def __getitem__(self, i):
...         print(i)
...         assert 0 <= i < 3
...         return i
... 
>>> class Foo2(torch.utils.data.Dataset):
...     def __len__(self):
...         return 3
...     def __getitem__(self, i):
...         print(i)
...         if 3 <= i:
...             raise IndexError()
...         return i
... 

# Assertion based index check: Since Dataset itself does not respect the __len__, it hits the assertion
>>> foo = Foo1()
>>> for _ in foo:
...     pass
... 
0
1
2
3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 6, in __getitem__
AssertionError

# IndexError based index check: Dataset catches the IndexError and recognize the termination of the loop.
>>> foo = Foo2()
>>> for _ in foo:
...     pass
... 
0
1
2
3
```

The same thing happens with FileCache and MultiprocessFileCache.
This PR is to make them consistent to this PyTorch behavior, by simply replacing the assertion by IndexError.

Note: Since NaiveCache is based on a list, it can accept the negative index (i<N). In contrast the file based caches requires positive index only (0<= i < N). For now I keep this behavior.

Severity of this PR: Since it is actually rare to iterate over a dataset without DataLoader, so we don't need to consider it as a critical improvement, but sometimes we do so when developing a Dataset class.