### PR TITLE
Add six to install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.5",
-    install_requires=['pyarrow'],
+    install_requires=['pyarrow', 'six'],
     include_package_data=True,
     zip_safe=False,
 


### PR DESCRIPTION
I failed to install `pfio` on fresh Python environment (`ModuleNotFoundError: No module named 'six'`).
pfio uses `six` but it is not listed in the dependency.