### PR TITLE
Introduce size limit to file caches

### DIFF
--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -102,8 +102,8 @@ class FileCache(cache.Cache):
             case home directory is not backed by fast storage device.
 
         cache_size_limit (None or int): Limitation of the cache size in bytes.
-            If the total amount of cached data reaches the limit,
-            the cache will become frozen and no longer acccept further addition.
+            If the total amount of cached data reaches the limit, the cache
+            will become frozen and no longer acccept further addition.
             Data already stored in the cache can be accessed normally.
             None (default) and 0 is unlimited.
 

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -1,5 +1,6 @@
 import errno
 import fcntl
+import numbers
 import os
 import tempfile
 import warnings
@@ -126,17 +127,32 @@ class MultiprocessFileCache(cache.Cache):
         dir (str): The path to the directory to place cache data in
             case home directory is not backed by fast storage device.
 
+        cache_size_limit (None or int): Limitation of the cache size in bytes.
+            If the total amount of cached data reaches the limit,
+            the cache will become frozen and no longer acccept further addition.
+            Data already stored in the cache can be accessed normally.
+            None (default) and 0 is unlimited.
+
         verbose (bool):
             Print detailed logs of the cache.
 
     '''  # NOQA
 
     def __init__(self, length, do_pickle=False,
-                 dir=None, verbose=False):
+                 dir=None, cache_size_limit=None, verbose=False):
         self.length = length
         self.do_pickle = do_pickle
         self.verbose = verbose
         assert self.length > 0
+
+        if not (cache_size_limit is None or
+                (isinstance(cache_size_limit, numbers.Number) and
+                 0 <= cache_size_limit)):
+            msg = "cache_size_limit has to be either None, zero " \
+                  "(both indicate unlimited) or larger than 0. " \
+                  "{} is specified.".format(cache_size_limit)
+            raise ValueError(msg)
+        self.cache_size_limit = cache_size_limit
 
         if dir is None:
             self.dir = _DEFAULT_CACHE_PATH
@@ -226,8 +242,8 @@ class MultiprocessFileCache(cache.Cache):
         return data
 
     def put(self, i, data):
-        if self._frozen:
-            return
+        if self._frozen or self.closed:
+            return False
 
         try:
             if self.do_pickle:
@@ -250,8 +266,16 @@ class MultiprocessFileCache(cache.Cache):
                              .format(i, self.length - 1))
 
         self._open_fds()
-        index_ofst = self.buflen * i
+
         fcntl.flock(self.index_fd, fcntl.LOCK_EX)
+        data_pos = os.lseek(self.data_fd, 0, os.SEEK_END)
+        if self.cache_size_limit:
+            if self.cache_size_limit < (data_pos + len(data)):
+                self._frozen = True
+                fcntl.flock(self.index_fd, fcntl.LOCK_UN)
+                return False
+
+        index_ofst = self.buflen * i
         buf = os.pread(self.index_fd, self.buflen, index_ofst)
         (o, l) = unpack('Qq', buf)
 
@@ -260,7 +284,6 @@ class MultiprocessFileCache(cache.Cache):
             fcntl.flock(self.index_fd, fcntl.LOCK_UN)
             return False
 
-        data_pos = os.lseek(self.data_fd, 0, os.SEEK_END)
         index_entry = pack('Qq', data_pos, len(data))
         assert os.pwrite(self.index_fd, index_entry, index_ofst) == self.buflen
         assert os.pwrite(self.data_fd, data, data_pos) == len(data)

--- a/tests/cache_tests/test_cache.py
+++ b/tests/cache_tests/test_cache.py
@@ -178,7 +178,8 @@ def test_cache_limit_ok(test_class):
     cache = make_cache(test_class, True, False, l,
                        cache_size_limit=100)
 
-    # To make sure the order of data to arrive has nothing to do with limitation logic
+    # To make sure the order of data to arrive
+    # has nothing to do with the size limitation logic
     idxs = list(range(l))
     random.shuffle(idxs)
 

--- a/tests/cache_tests/test_multiprocess_file_cache.py
+++ b/tests/cache_tests/test_multiprocess_file_cache.py
@@ -55,7 +55,7 @@ def test_cleanup_subprocess():
 
 
 def test_multiprocess_consistency():
-    # Condition: 32k samples (8k*4bytes each) cached by 64 workers.
+    # Condition: 32k samples (8k*4bytes each) cached by 32 workers.
     # Each sample is an array of repeated sample index.
     # ie. k-th sample is np.array([k, k, k, ..., k], dtype=np.int32)
     # 32 worker processes simultaneously create such data and insert them into
@@ -77,9 +77,9 @@ def test_multiprocess_consistency():
         # Add tons of data into the cache in parallel
         ps = [multiprocessing.Process(target=child, args=(cache, worker_idx))
               for worker_idx in range(n_workers)]
-        for i, p in enumerate(ps):
+        for p in ps:
             p.start()
-        for i, p in enumerate(ps):
+        for p in ps:
             p.join()
 
         # Get each sample from the cache and check the content


### PR DESCRIPTION
This PR introduces size limitation (in bytes) of cache data file in `FileCache` and `MultiprocessFileCache`.

### Background

Since the file caches are essentially to make a local copy of the entire dataset, they can easily run out of local disk accidentally.
In order to deal with it, the current file caches already handle `errno=ENOSPC` properly, i.e., even when disk full it does not die but just warn without adding the data.

However in some situations this might not be sufficient:
- We basically want to always keep sufficient amount of free space in local (say, GBs) for system stability
- In kubernetes environment, a pod which runs out of local disk will be Evicted (=killed) *before actually getting ENOSPC*


### Functionality

In this PR, the `cache_size_limit` option is added to `FileCache` and `MultiprocessFileCache` respectively.
By default it is set `None`, which means no limitation. So is 0.

In case a valid number is specified, when the total amount of cache data file reaches to the limit, the cache will no longer accept further data addition by changing the cache mode to `frozen`.
The part of cache already built until then can be utilized as usual.


### Known issue

- When multiple `FileCache` or `MultiprocessFileCache` instances exist, there's still a risk for disk exhaustion
    - I think we can make it user's responsibility to set appropriate limitations to each of cache.
- Index file size is not taken into account
    - The file cache has index file which is an LUT for data position as well as data file
    - In this PR, only data file size is considered.
    - Usually size of indices is trivial compared to data (in ImageNet case, index=20MB vs data=34GB)