### PR TITLE
Single cache file

### DIFF
--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -1,3 +1,4 @@
+import errno
 import numbers
 import os
 from struct import pack, unpack, calcsize
@@ -116,7 +117,8 @@ class FileCache(cache.Cache):
         self._multithread_safe = multithread_safe
         self.length = length
         self.do_pickle = do_pickle
-        assert self.length > 0
+        if self.length <= 0 or (2 ** 64) <= self.length:
+            raise ValueError("length has to be between 0 and 2^64")
 
         if not (cache_size_limit is None or
                 (isinstance(cache_size_limit, numbers.Number) and
@@ -132,7 +134,6 @@ class FileCache(cache.Cache):
         else:
             self.lock = DummyLock()
 
-        self.pos = 0
         if dir is None:
             self.dir = _DEFAULT_CACHE_PATH
         else:
@@ -140,23 +141,22 @@ class FileCache(cache.Cache):
         os.makedirs(self.dir, exist_ok=True)
 
         self.closed = False
-        self.indexfp = tempfile.NamedTemporaryFile(delete=True, dir=self.dir)
-        self.datafp = tempfile.NamedTemporaryFile(delete=True, dir=self.dir)
+        self.cachefp = tempfile.NamedTemporaryFile(delete=True, dir=self.dir)
 
-        # allocate space to store 2n 64bit unsigned integers
-        # 16 bytes * n chunks
-        # Size must be smaller than max value of signed long long
+        # allocate space to store 2n uint64 index buffer filled by -1.
+        # the cache data will be appended after the indices.
         buf = pack('Qq', 0, -1)
         self.buflen = calcsize('Qq')
         assert self.buflen == 16
         for i in range(self.length):
             offset = self.buflen * i
-            r = os.pwrite(self.indexfp.fileno(), buf, offset)
+            r = os.pwrite(self.cachefp.fileno(), buf, offset)
             assert r == self.buflen
+        self.pos = self.buflen * self.length
+
         self.verbose = verbose
         if self.verbose:
-            print('created index file:', self.indexfp.name)
-            print('created data file:', self.datafp.name)
+            print('created cache file:', self.cachefp.name)
 
         self._frozen = False
 
@@ -169,8 +169,7 @@ class FileCache(cache.Cache):
 
     @property
     def multiprocess_safe(self):
-        # If it's preseved/preloaded, then the file contents are
-        # fixed.
+        # If it's preseved/preloaded, then the file contents are fixed.
         return self._frozen
 
     @property
@@ -192,12 +191,12 @@ class FileCache(cache.Cache):
 
         offset = self.buflen * i
         with self.lock.rdlock():
-            buf = os.pread(self.indexfp.fileno(), self.buflen, offset)
+            buf = os.pread(self.cachefp.fileno(), self.buflen, offset)
             (o, l) = unpack('Qq', buf)
             if l < 0 or o < 0:
                 return None
 
-            data = os.pread(self.datafp.fileno(), l, o)
+            data = os.pread(self.cachefp.fileno(), l, o)
             assert len(data) == l
             return data
 
@@ -212,7 +211,7 @@ class FileCache(cache.Cache):
 
         except OSError as ose:
             # Disk full (ENOSPC) possibly by cache; just warn and keep running
-            if ose.errno == 28:
+            if ose.errno == errno.ENOSPC:
                 warnings.warn(ose.strerror, RuntimeWarning)
                 return False
             else:
@@ -232,7 +231,7 @@ class FileCache(cache.Cache):
 
         offset = self.buflen * i
         with self.lock.wrlock():
-            buf = os.pread(self.indexfp.fileno(), self.buflen, offset)
+            buf = os.pread(self.cachefp.fileno(), self.buflen, offset)
             (o, l) = unpack('Qq', buf)
             if l >= 0 and o >= 0:
                 # Already data exists
@@ -257,12 +256,12 @@ class FileCache(cache.Cache):
 
             '''
             buf = pack('Qq', pos, len(data))
-            r = os.pwrite(self.indexfp.fileno(), buf, offset)
+            r = os.pwrite(self.cachefp.fileno(), buf, offset)
             assert r == self.buflen
 
             current_pos = pos
             while current_pos - pos < len(data):
-                r = os.pwrite(self.datafp.fileno(),
+                r = os.pwrite(self.cachefp.fileno(),
                               data[current_pos-pos:], current_pos)
                 assert r > 0
                 current_pos += r
@@ -281,10 +280,8 @@ class FileCache(cache.Cache):
         with self.lock.wrlock():
             if not self.closed:
                 self.closed = True
-                self.indexfp.close()
-                self.datafp.close()
-                self.indexfp = None
-                self.datafp = None
+                self.cachefp.close()
+                self.cachefp = None
 
     def preload(self, name):
         '''Load the cache saved by ``preserve()``
@@ -300,16 +297,11 @@ class FileCache(cache.Cache):
         if self._frozen:
             return
 
-        indexfile = os.path.join(self.dir, '{}.cachei'.format(name))
-        datafile = os.path.join(self.dir, '{}.cached'.format(name))
+        cachefile = os.path.join(self.dir, name)
 
         with self.lock.wrlock():
-            # Hard link and save them
-            self.indexfp.close()
-            self.datafp.close()
-
-            self.indexfp = open(indexfile, 'rb')
-            self.datafp = open(datafile, 'rb')
+            self.cachefp.close()
+            self.cachefp = open(cachefile, 'rb')
             self._frozen = True
 
     def preserve(self, name):
@@ -318,8 +310,7 @@ class FileCache(cache.Cache):
         Once the cache is preserved, cache files will not be removed
         at cache close. To read data from preserved files, use
         ``preload()`` method. After preservation, no data can be added
-        to the cache.  ``name`` is the prefix of the persistent
-        files.
+        to the cache.  ``name`` is the prefix of the persistent files.
 
         The preserved cache can also be preloaded by
         :class:`~MultiprocessFileCache`.
@@ -328,16 +319,12 @@ class FileCache(cache.Cache):
 
         '''
 
-        indexfile = os.path.join(self.dir, '{}.cachei'.format(name))
-        datafile = os.path.join(self.dir, '{}.cached'.format(name))
+        cachefile = os.path.join(self.dir, name)
 
         with self.lock.wrlock():
             # Hard link and save them
-            os.link(self.indexfp.name, indexfile)
-            os.link(self.datafp.name, datafile)
-            self.indexfp.close()
-            self.datafp.close()
+            os.link(self.cachefp.name, cachefile)
+            self.cachefp.close()
 
-            self.indexfp = open(indexfile, 'rb')
-            self.datafp = open(datafile, 'rb')
+            self.cachefp = open(cachefile, 'rb')
             self._frozen = True

--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -81,7 +81,7 @@ class DummyLock:
 class FileCache(cache.Cache):
     '''Cache system with local filesystem
 
-    Stores cache data in local temporary files, created in
+    Stores cache data in a local temporary file created in
     ``~/.pfio/cache`` by default. Cache data is
     automatically deleted after the object is collected. When this
     object is not correctly closed, (e.g., the process killed by
@@ -286,10 +286,10 @@ class FileCache(cache.Cache):
     def preload(self, name):
         '''Load the cache saved by ``preserve()``
 
-        After loading the files, no data can be added to the cache.
-        ``name`` is the prefix of the persistent files. To use cache
+        ``cache_path`` is the path to the persistent file. To use cache
         in ``multiprocessing`` environment, call this method at every
         forked process, except the process that called ``preserve()``.
+        After the preload, no data can be added to the cache.
 
         .. note:: This feature is experimental.
 
@@ -305,12 +305,13 @@ class FileCache(cache.Cache):
             self._frozen = True
 
     def preserve(self, name):
-        '''Preserve the cache as persistent files on the disk
+        '''Preserve the cache as a persistent file on the disk
 
-        Once the cache is preserved, cache files will not be removed
-        at cache close. To read data from preserved files, use
+        Saves the current cache into ``cache_path``.
+        Once the cache is preserved, the cache file will not be removed
+        at cache close. To read data from the preserved file, use
         ``preload()`` method. After preservation, no data can be added
-        to the cache.  ``name`` is the prefix of the persistent files.
+        to the cache.
 
         The preserved cache can also be preloaded by
         :class:`~MultiprocessFileCache`.

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -59,7 +59,7 @@ class _DummyTemporaryFile(object):
 class MultiprocessFileCache(cache.Cache):
     '''The Multiprocess-safe cache system on a local filesystem
 
-    Stores cache data in local temporary files, created in ``~/.pfio/cache``
+    Stores cache data in a local temporary file, created in ``~/.pfio/cache``
     by default. It automatically deletes the cache data after the object is
     collected. When this object is not correctly closed (e.g., the process
     killed by SIGKILL), the cache remains after the process's death.
@@ -67,8 +67,8 @@ class MultiprocessFileCache(cache.Cache):
     This class supports handling a cache from multiple processes.
     A MultiprocessFileCache object can be handed over to another process
     through the pickle. Calling ``get`` and ``put`` in each process will
-    look into the same cache files with flock-based locking. The temporary
-    cache files will persist as long as the MultiprocessFileCache object is
+    look into the same cache file with flock-based locking. The temporary
+    cache file will persist as long as the MultiprocessFileCache object is
     alive in the original process that creates it.
     Therefore, even after destroying the worker processes,
     the MultiprocessFileCache object can still be passed to another process.
@@ -115,7 +115,7 @@ class MultiprocessFileCache(cache.Cache):
        i.e., ``num_workers=0`` in DataLoader, consider using :class:`~FileCache`
        as it has less overhead for concurrency control.
 
-       The persisted cache files created by ``preserve()`` can be used for
+       The persisted cache file created by ``preserve()`` can be used for
        :meth:`FileCache.preload` and vice versa.
 
     Arguments:
@@ -327,7 +327,7 @@ class MultiprocessFileCache(cache.Cache):
             raise RuntimeError("Cannot preload a cache in a worker process")
 
         # Overwrite the current cache by the specified cache file.
-        # This is needed to prevent the specified cache files are deleted when
+        # This is needed to prevent the specified cache file are deleted when
         # the cache object is destroyed.
         ld_cache_file = os.path.join(self.dir, name)
         if not os.path.exists(ld_cache_file):
@@ -342,8 +342,8 @@ class MultiprocessFileCache(cache.Cache):
     def preserve(self, name):
         '''Preserve the cache as a persistent file on the disk
 
-        Once the cache is preserved, cache files will not be removed
-        at cache close. To read data from preserved files, use
+        Once the cache is preserved, the cache file will not be removed
+        at cache close. To read data from preserved file, use
         ``preload()`` method. After preservation, no data can be added
         to the cache. ``name`` is the name of the persistent files saved into
         the cache directory.

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -143,7 +143,8 @@ class MultiprocessFileCache(cache.Cache):
         self.length = length
         self.do_pickle = do_pickle
         self.verbose = verbose
-        assert self.length > 0
+        if self.length <= 0 or (2 ** 64) <= self.length:
+            raise ValueError("length has to be between 0 and 2^64")
 
         if not (cache_size_limit is None or
                 (isinstance(cache_size_limit, numbers.Number) and
@@ -163,24 +164,22 @@ class MultiprocessFileCache(cache.Cache):
         self.closed = False
         self._frozen = False
         self._master_pid = os.getpid()
-        self.data_file = _NoOpenNamedTemporaryFile(self.dir, self._master_pid)
-        self.index_file = _NoOpenNamedTemporaryFile(self.dir, self._master_pid)
-        index_fd = os.open(self.index_file.name, os.O_RDWR)
+        self.cache_file = _NoOpenNamedTemporaryFile(self.dir, self._master_pid)
+        cache_fd = os.open(self.cache_file.name, os.O_RDWR)
 
         if self.verbose:
-            print('created index file:', self.index_file.name)
-            print('created data file:', self.data_file.name)
+            print('created cache file:', self.cache_file.name)
 
         try:
-            fcntl.flock(index_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(cache_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-            # Fill up index file by index=0, size=-1
+            # Fill up indices part of the cache file by index=0, size=-1
             buf = pack('Qq', 0, -1)
             self.buflen = calcsize('Qq')
             assert self.buflen == 16
             for i in range(self.length):
                 offset = self.buflen * i
-                r = os.pwrite(index_fd, buf, offset)
+                r = os.pwrite(cache_fd, buf, offset)
                 assert r == self.buflen
         except OSError as ose:
             # Lock acquisition error -> No problem, since other worker
@@ -188,13 +187,12 @@ class MultiprocessFileCache(cache.Cache):
             if ose.errno not in (errno.EACCES, errno.EAGAIN):
                 raise
         finally:
-            fcntl.flock(index_fd, fcntl.LOCK_UN)
-            os.close(index_fd)
+            fcntl.flock(cache_fd, fcntl.LOCK_UN)
+            os.close(cache_fd)
 
         # Open lazily at the first call of get or put in each child process
         self._fd_pid = None
-        self.index_fd = None
-        self.data_fd = None
+        self.cache_fd = None
 
     def __len__(self):
         return self.length
@@ -219,8 +217,7 @@ class MultiprocessFileCache(cache.Cache):
         pid = os.getpid()
         if self._fd_pid != pid:
             self._fd_pid = pid
-            self.index_fd = os.open(self.index_file.name, os.O_RDWR)
-            self.data_fd = os.open(self.data_file.name, os.O_RDWR)
+            self.cache_fd = os.open(self.cache_file.name, os.O_RDWR)
 
     def _get(self, i):
         if i < 0 or self.length <= i:
@@ -229,16 +226,16 @@ class MultiprocessFileCache(cache.Cache):
 
         self._open_fds()
         offset = self.buflen * i
-        fcntl.flock(self.index_fd, fcntl.LOCK_SH)
-        index_entry = os.pread(self.index_fd, self.buflen, offset)
+        fcntl.flock(self.cache_fd, fcntl.LOCK_SH)
+        index_entry = os.pread(self.cache_fd, self.buflen, offset)
         (o, l) = unpack('Qq', index_entry)
         if l < 0 or o < 0:
-            fcntl.flock(self.index_fd, fcntl.LOCK_UN)
+            fcntl.flock(self.cache_fd, fcntl.LOCK_UN)
             return None
 
-        data = os.pread(self.data_fd, l, o)
+        data = os.pread(self.cache_fd, l, o)
         assert len(data) == l
-        fcntl.flock(self.index_fd, fcntl.LOCK_UN)
+        fcntl.flock(self.cache_fd, fcntl.LOCK_UN)
         return data
 
     def put(self, i, data):
@@ -267,29 +264,28 @@ class MultiprocessFileCache(cache.Cache):
 
         self._open_fds()
 
-        fcntl.flock(self.index_fd, fcntl.LOCK_EX)
-        data_pos = os.lseek(self.data_fd, 0, os.SEEK_END)
-        if self.cache_size_limit:
-            if self.cache_size_limit < (data_pos + len(data)):
-                self._frozen = True
-                fcntl.flock(self.index_fd, fcntl.LOCK_UN)
-                return False
-
         index_ofst = self.buflen * i
-        buf = os.pread(self.index_fd, self.buflen, index_ofst)
+        fcntl.flock(self.cache_fd, fcntl.LOCK_EX)
+        buf = os.pread(self.cache_fd, self.buflen, index_ofst)
         (o, l) = unpack('Qq', buf)
 
         if l >= 0 and o >= 0:
             # Already data exists
-            fcntl.flock(self.index_fd, fcntl.LOCK_UN)
+            fcntl.flock(self.cache_fd, fcntl.LOCK_UN)
             return False
 
+        data_pos = os.lseek(self.cache_fd, 0, os.SEEK_END)
+        if self.cache_size_limit:
+            if self.cache_size_limit < (data_pos + len(data)):
+                self._frozen = True
+                fcntl.flock(self.cache_fd, fcntl.LOCK_UN)
+                return False
+
         index_entry = pack('Qq', data_pos, len(data))
-        assert os.pwrite(self.index_fd, index_entry, index_ofst) == self.buflen
-        assert os.pwrite(self.data_fd, data, data_pos) == len(data)
-        os.fsync(self.index_fd)
-        os.fsync(self.data_fd)
-        fcntl.flock(self.index_fd, fcntl.LOCK_UN)
+        assert os.pwrite(self.cache_fd, index_entry, index_ofst) == self.buflen
+        assert os.pwrite(self.cache_fd, data, data_pos) == len(data)
+        os.fsync(self.cache_fd)
+        fcntl.flock(self.cache_fd, fcntl.LOCK_UN)
         return True
 
     def __enter__(self):
@@ -302,24 +298,20 @@ class MultiprocessFileCache(cache.Cache):
         pid = os.getpid()
 
         if pid == self._fd_pid:
-            os.close(self.data_fd)
-            os.close(self.index_fd)
+            os.close(self.cache_fd)
             self._fd_pid = None
 
         if not self.closed and pid == self._master_pid:
-            self.data_file.close()
-            self.index_file.close()
+            self.cache_file.close()
             self.closed = True
-            self.data_file = None
-            self.index_file = None
-            self.data_fd = None
-            self.index_fd = None
+            self.cache_file = None
+            self.cache_fd = None
 
     def preload(self, name):
         '''Load the cache saved by ``preserve()``
 
-        After loading the files, no data can be added to the cache.
-        ``name`` is the prefix of the persistent files.
+        After loading the file, no data can be added to the cache.
+        ``name`` is the name of the persistent file in the cache directory.
 
         Be noted that ``preload()`` can be called only by the master process
         i.e., the process where ``__init__()`` is called,
@@ -337,28 +329,24 @@ class MultiprocessFileCache(cache.Cache):
         # Overwrite the current cache by the specified cache file.
         # This is needed to prevent the specified cache files are deleted when
         # the cache object is destroyed.
-        ld_index_file = os.path.join(self.dir, '{}.cachei'.format(name))
-        ld_data_file = os.path.join(self.dir, '{}.cached'.format(name))
-        if any(not os.path.exists(p) for p in (ld_index_file, ld_data_file)):
-            raise ValueError('Specified cache "{}" not found in {}'
-                             .format(name, self.dir))
+        ld_cache_file = os.path.join(self.dir, name)
+        if not os.path.exists(ld_cache_file):
+            raise FileNotFoundError('Specified cache "{}" not found in {}'
+                                    .format(name, self.dir))
 
-        self.data_file.close()
-        self.index_file.close()
-        self.data_fd = None
-        self.index_fd = None
-        self.data_file = _DummyTemporaryFile(ld_data_file)
-        self.index_file = _DummyTemporaryFile(ld_index_file)
+        self.cache_file.close()
+        self.cache_fd = None
+        self.cache_file = _DummyTemporaryFile(ld_cache_file)
         self._frozen = True
 
     def preserve(self, name):
-        '''Preserve the cache as persistent files on the disk
+        '''Preserve the cache as a persistent file on the disk
 
         Once the cache is preserved, cache files will not be removed
         at cache close. To read data from preserved files, use
         ``preload()`` method. After preservation, no data can be added
-        to the cache.  ``name`` is the prefix of the persistent
-        files.
+        to the cache. ``name`` is the name of the persistent files saved into
+        the cache directory.
 
         Be noted that ``preserve()`` can be called only by the master process
         i.e., the process where ``__init__()`` is called,
@@ -373,18 +361,16 @@ class MultiprocessFileCache(cache.Cache):
         if self._master_pid != os.getpid():
             raise RuntimeError("Cannot preserve a cache in a worker process")
 
-        index_file = os.path.join(self.dir, '{}.cachei'.format(name))
-        data_file = os.path.join(self.dir, '{}.cached'.format(name))
-
-        if any(os.path.exists(p) for p in (index_file, data_file)):
-            raise ValueError('Specified cache name "{}" already exists in {}'
-                             .format(name, self.dir))
+        cache_file = os.path.join(self.dir, name)
+        if os.path.exists(cache_file):
+            msg = 'Specified cache name "{}" already exists in {}' \
+                  .format(name, self.dir)
+            raise FileExistsError(msg)
 
         self._open_fds()
         try:
-            fcntl.flock(self.index_fd, fcntl.LOCK_EX)
-            os.link(self.index_file.name, index_file)
-            os.link(self.data_file.name, data_file)
+            fcntl.flock(self.cache_fd, fcntl.LOCK_EX)
+            os.link(self.cache_file.name, cache_file)
 
         except OSError as ose:
             # Lock acquisition error -> No problem, since other worker
@@ -392,4 +378,4 @@ class MultiprocessFileCache(cache.Cache):
             if ose.errno not in (errno.EACCES, errno.EAGAIN):
                 raise
         finally:
-            fcntl.flock(self.index_fd, fcntl.LOCK_UN)
+            fcntl.flock(self.cache_fd, fcntl.LOCK_UN)

--- a/tests/cache_tests/test_cache.py
+++ b/tests/cache_tests/test_cache.py
@@ -175,8 +175,12 @@ def test_cache_limit_invalid_limits(test_class):
 def test_cache_limit_ok(test_class):
     sample_size = 10
     l = 20
+
+    # index part = 8x2xl = 320(bytes)
+    # data part = 100(bytes)
     cache = make_cache(test_class, True, False, l,
-                       cache_size_limit=100)
+                       cache_size_limit=(320 + 100))
+    assert len(cache) == l
 
     # To make sure the order of data to arrive
     # has nothing to do with the size limitation logic
@@ -186,18 +190,18 @@ def test_cache_limit_ok(test_class):
     # It accepts the data until reaching to size limit
     data = b'x' * sample_size
     for i in idxs[:10]:
-        assert cache.put(i, data)
+        cache.put(i, data)
 
         # To make sure reading the data while putting data
         # doesn't interfere
         j = random.randrange(l)
         cache.get(j)
 
-    # It no longet accept pushing further
+    # More data cannot be accepted (though not error)
     for i in idxs[10:]:
-        assert not cache.put(i, data)
+        cache.put(i, data)
 
-    # Data already cached should remain intact
+    # Data already cached should remain
     for i in idxs[:10]:
         assert cache.get(i) == data
 
@@ -208,16 +212,23 @@ def test_cache_limit_ok(test_class):
 
 @pytest.mark.parametrize("test_class", [FileCache, MultiprocessFileCache])
 def test_cache_limit_auto_freeze(test_class):
-    cache = make_cache(test_class, True, False, 10,
-                       cache_size_limit=120)
+    l = 10
+
+    # index part = 8x2x10(bytes)
+    # data part = 120(bytes)
+    cache = make_cache(test_class, True, False, l,
+                       cache_size_limit=(160 + 120))
 
     data_50bytes = b'x' * 50
     cache.put(0, data_50bytes)
     cache.put(1, data_50bytes)
     assert not cache.put(2, data_50bytes)   # Here it reaches to the limit
 
+    assert cache.get(0) == data_50bytes
+    assert cache.get(1) == data_50bytes
+
     # This cache is now frozen; no longer accepts further put,
-    # although the next data is small enough for the remained size.
+    # even if the next data is small enough for the remained size.
     data_20bytes = b'y' * 20
     assert not cache.put(3, data_20bytes)
     assert cache.get(3) is None

--- a/tests/cache_tests/test_file_cache.py
+++ b/tests/cache_tests/test_file_cache.py
@@ -54,6 +54,31 @@ def test_preservation():
             assert str(i) == cache2.get(i)
 
 
+def test_preservation_error_already_exists():
+    with tempfile.TemporaryDirectory() as d:
+        cache = FileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        cache.preserve('preserved')
+
+        with pytest.raises(FileExistsError):
+            cache.preserve('preserved')
+
+        cache.close()
+
+
+def test_preload_error_not_found():
+    with tempfile.TemporaryDirectory() as d:
+        cache = FileCache(10, dir=d, do_pickle=True)
+
+        with pytest.raises(FileNotFoundError):
+            cache.preload('preserved')
+
+        cache.close()
+
+
 def test_preservation_interoperability():
     with tempfile.TemporaryDirectory() as d:
         cache = FileCache(10, dir=d, do_pickle=True)

--- a/tests/cache_tests/test_multiprocess_file_cache.py
+++ b/tests/cache_tests/test_multiprocess_file_cache.py
@@ -28,7 +28,7 @@ def test_cleanup():
         for i in range(10):
             cache.put(i, str(i))
 
-        assert len(os.listdir(d)) == 2
+        assert len(os.listdir(d)) == 1
 
         cache.close()
 
@@ -47,7 +47,7 @@ def test_cleanup_subprocess():
 
         # Calling close in the subprocess should not
         # delete the cache files
-        assert len(os.listdir(d)) == 2
+        assert len(os.listdir(d)) == 1
 
         cache.close()
 
@@ -111,7 +111,7 @@ def test_preservation():
 
         # No temporary cache file should remain,
         # and the preserved cache should be kept.
-        assert os.listdir(d) == ['preserved.cached', 'preserved.cachei']
+        assert os.listdir(d) == ['preserved']
 
 
 def test_preservation_interoperability():
@@ -143,7 +143,7 @@ def test_preservation_error_already_exists():
 
         cache.preserve('preserved')
 
-        with pytest.raises(ValueError):
+        with pytest.raises(FileExistsError):
             cache.preserve('preserved')
 
         cache.close()
@@ -180,7 +180,7 @@ def test_preload_error_not_found():
     with tempfile.TemporaryDirectory() as d:
         cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(FileNotFoundError):
             cache.preload('preserved')
 
         cache.close()


### PR DESCRIPTION
Currently file caches (FileCache and MultiprocessFileCache) save the cache information separately into index file and data file.
This PR is to propose to change it to single file.

The new cache file is formatted as:
- index part: (8 bytes sample offset + 8 bytes sample size) * N
- data part: (arbitrary size of binary data) * N

where N is the number of samples to cache.
This is actually completely equivalent to just concatenating the current index and data file.

## Background

### More strict cache size limitation (related to #143)
#143 will introduce limitation of cache data, however currently it is limited to data file only.
It is usually OK - as the index files are relatively negligible in most cases (e.g., ImageNet1K case 34GB vs 20MB), but as the number of parallelism grows the index file increases, which becomes relatively non-trivial, but they'll be out of limitation.
By unifying the index and data file into one file, we can constrain the cache size more strictly. 

### Easier handling
In case we want to fully utilize cache `preserve` and `preload` functionality, if the preserved cache is a single file it is easier to handle/manage.

### Performance concern

@kuenishi has pointed out that since in a single-file cache, every time we access to the cache it reads the file twice (to get index and actually data), which may increase chance of conflict in multi-process use.
To be studied.