### PR TITLE
File access V2 API

### DIFF
--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -1,4 +1,8 @@
 import sys
+import warnings
+
+warnings.warn("package 'chainerio' is deprecated and will be removed. Please use 'pfio' instead.",
+              DeprecationWarning)
 
 # make sure pfio is in sys.modules
 import pfio  # NOQA

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -1,7 +1,8 @@
 import sys
 import warnings
 
-warnings.warn("package 'chainerio' is deprecated and will be removed. Please use 'pfio' instead.",
+warnings.warn("package 'chainerio' is deprecated and will be removed."
+              " Please use 'pfio' instead.",
               DeprecationWarning)
 
 # make sure pfio is in sys.modules

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,8 @@ Welcome to PFIO's documentation!
 
    design
    reference
+   v2
+
 
 Indices and tables
 ==================

--- a/docs/source/v2.rst
+++ b/docs/source/v2.rst
@@ -1,0 +1,62 @@
+.. module:: pfio.v2
+
+V2 API
+======
+
+.. note:: this is still in exprerimental phase.
+
+
+PFIO v2 API tries to solve the impedance mismatch between different
+local filesystem, NFS, and other object storage systems, with a lot
+simpler and cleaner code.
+
+It has removed several toplevel functions that seem to be less
+important. It turned out that they introduced more complexity than
+originally intended, due to the need of the global context. Thus,
+functions that depends on the global context such as ``open()``,
+``set_root()`` and etc. have been removed in v2 API.
+
+Instead, v2 API provides only two toplevel functions that enable
+direct resource access with full URL: ``open_url()`` and
+``fs.from_url()``. The former opens a file and returns FileObject. The
+latter, creates a ``fs.FS`` object that enable resource access under
+the URL. The new class ``fs.FS``, is something close to handler object
+in version 1 API. ``fs.FS`` is intended to be as much compatible as
+possible, however, it has several differences.
+
+One notable difference is that it has the virtual concept of current
+working directory, and thus provides ``subfs()`` method. ``subfs()``
+method behaves like ``os.chdir()`` without actually changing current
+working directory of the process, but actually returns a *new*
+``fs.FS`` object that has different working directory. All resouce
+access through the object automatically prepends the working
+directory.
+
+V2 API does not provide lazy resouce initialization any more. Instead,
+it provides simple wrapper ``recreate_on_fork``, which recreates the
+``fs.FS`` object every time the object experiences ``fork(2)``. ``Hdfs``
+and ``Zip`` can be wrapped with it, and will be fork-tolerant object.
+
+
+
+Reference
+---------
+
+.. autofunction:: open_url
+.. autofunction:: pfio.v2.fs.from_url
+.. autofunction:: pfio.v2.fs.recreate_on_fork
+
+.. autoclass:: pfio.v2.fs.FS
+   :members:
+.. autoclass:: Local
+   :members:
+.. autoclass:: Hdfs
+   :members:
+.. autoclass:: S3
+   :members:
+.. autoclass:: Zip
+   :members:
+
+.. note::
+          Only the username in the first entry in The
+          keytab will be used to update the Kerberos ticket.

--- a/docs/source/v2.rst
+++ b/docs/source/v2.rst
@@ -18,7 +18,7 @@ functions that depends on the global context such as ``open()``,
 
 Instead, v2 API provides only two toplevel functions that enable
 direct resource access with full URL: ``open_url()`` and
-``fs.from_url()``. The former opens a file and returns FileObject. The
+``from_url()``. The former opens a file and returns FileObject. The
 latter, creates a ``fs.FS`` object that enable resource access under
 the URL. The new class ``fs.FS``, is something close to handler object
 in version 1 API. ``fs.FS`` is intended to be as much compatible as
@@ -26,16 +26,16 @@ possible, however, it has several differences.
 
 One notable difference is that it has the virtual concept of current
 working directory, and thus provides ``subfs()`` method. ``subfs()``
-method behaves like ``os.chdir()`` without actually changing current
-working directory of the process, but actually returns a *new*
+method behaves like chroot or ``os.chdir()`` without actually changing
+current working directory of the process, but actually returns a *new*
 ``fs.FS`` object that has different working directory. All resouce
 access through the object automatically prepends the working
 directory.
 
 V2 API does not provide lazy resouce initialization any more. Instead,
-it provides simple wrapper ``recreate_on_fork``, which recreates the
-``fs.FS`` object every time the object experiences ``fork(2)``. ``Hdfs``
-and ``Zip`` can be wrapped with it, and will be fork-tolerant object.
+it provides simple wrapper ``lazify()``, which recreates the ``fs.FS``
+object every time the object experiences ``fork(2)``. ``Hdfs`` and
+``Zip`` can be wrapped with it, and will be fork-tolerant object.
 
 
 
@@ -43,8 +43,8 @@ Reference
 ---------
 
 .. autofunction:: open_url
-.. autofunction:: pfio.v2.fs.from_url
-.. autofunction:: pfio.v2.fs.recreate_on_fork
+.. autofunction:: from_url
+.. autofunction:: lazify
 
 .. autoclass:: pfio.v2.fs.FS
    :members:
@@ -56,7 +56,3 @@ Reference
    :members:
 .. autoclass:: Zip
    :members:
-
-.. note::
-          Only the username in the first entry in The
-          keytab will be used to update the Kerberos ticket.

--- a/docs/source/v2.rst
+++ b/docs/source/v2.rst
@@ -26,11 +26,11 @@ possible, however, it has several differences.
 
 One notable difference is that it has the virtual concept of current
 working directory, and thus provides ``subfs()`` method. ``subfs()``
-method behaves like chroot or ``os.chdir()`` without actually changing
-current working directory of the process, but actually returns a *new*
-``fs.FS`` object that has different working directory. All resouce
-access through the object automatically prepends the working
-directory.
+method behaves like ``chroot(1)`` or ``os.chdir()`` without actually
+changing current working directory of the process, but actually
+returns a *new* ``fs.FS`` object that has different working
+directory. All resouce access through the object automatically
+prepends the working directory.
 
 V2 API does not provide lazy resouce initialization any more. Instead,
 it provides simple wrapper ``lazify()``, which recreates the ``fs.FS``
@@ -46,13 +46,30 @@ Reference
 .. autofunction:: from_url
 .. autofunction:: lazify
 
+
 .. autoclass:: pfio.v2.fs.FS
    :members:
+
+Local file system
+~~~~~~~~~~~~~~~~~
+
 .. autoclass:: Local
    :members:
+
+HDFS (Hadoop File System)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. autoclass:: Hdfs
    :members:
+
+S3 (AWS S3)
+~~~~~~~~~~~
+
 .. autoclass:: S3
    :members:
+
+Zip Archive
+~~~~~~~~~~~
+
 .. autoclass:: Zip
    :members:

--- a/pfio/chainer_extensions/__init__.py
+++ b/pfio/chainer_extensions/__init__.py
@@ -1,1 +1,7 @@
+import warnings
+
 from pfio.chainer_extensions.snapshot import load_snapshot  # NOQA
+
+warnings.warn("Chainer extentions are deprecated and "
+              "will be removed. Please use 'pfio' instead.",
+              DeprecationWarning)

--- a/pfio/io.py
+++ b/pfio/io.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Iterator, Type
 
 from pfio._typing import Optional
 from pfio.profiler import IOProfiler
+from pfio.v2.fs import FileStat
 
 
 def open_wrapper(func):
@@ -23,53 +24,6 @@ def open_wrapper(func):
             file_obj, file_path, mode, buffering, encoding,
             errors, newline, closefd, opener)
     return wrapper
-
-
-class FileStat(abc.ABC):
-    """Detailed file or directory information abstraction
-
-    :meth:`pfio.IO.stat` of filesystem/container handlers return an object of
-    subclass of ``FileStat``.
-    In addition to the common attributes that the ``FileStat`` abstract
-    provides, each ``FileStat`` subclass implements some additional
-    attributes depending on what information the corresponding filesystem or
-    container can handle.
-    The common attributes have the same behavior despite filesystem or
-    container type difference.
-
-    Attributes:
-        filename (str):
-            Filename in the filesystem or container.
-        last_modifled (float):
-            UNIX timestamp of mtime. Note that some
-            filesystems or containers do not have sub-second precision.
-        mode (int):
-            Permission with file type flag (regular file or directory).
-            You can make a human-readable interpretation by
-            `stat.filemode <https://docs.python.org/3/library/stat.html#stat.filemode>`_.
-        size (int):
-            Size in bytes. Note that directories may have different
-            sizes depending on the filesystem or container type.
-    """     # NOQA
-    filename = None
-    last_modified = None
-    mode = None
-    size = None
-
-    def isdir(self):
-        """Returns whether the target is a directory, based on the permission flag
-
-        Returns:
-            `True` if directory, `False` otherwise.
-        """
-        return bool(self.mode & 0o40000)
-
-    def __str__(self):
-        return '<{} filename="{}" mode="{}">'.format(
-            type(self).__name__, self.filename, stat.filemode(self.mode))
-
-    def __repr__(self):
-        return str(self.__str__())
 
 
 class IO(abc.ABC):

--- a/pfio/io.py
+++ b/pfio/io.py
@@ -1,5 +1,4 @@
 import abc
-import stat
 from abc import abstractmethod
 from importlib import import_module
 from io import IOBase

--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -23,7 +23,6 @@ class ZipForTest:
         d = self.data
 
         for node in path.split(os.path.sep):
-            print(node)
             d = d.get(node)
             if not isinstance(d, dict):
                 return d

--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -1,7 +1,6 @@
 import os
 import random
 import string
-import tempfile
 from zipfile import ZipFile
 
 

--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -1,0 +1,65 @@
+import os
+import random
+import string
+import tempfile
+from zipfile import ZipFile
+
+
+class ZipForTest:
+    def __init__(self, destfile, data=None):
+        if data is None:
+            self.data = dict(
+                file=b"foo",
+                dir=dict(
+                    f=b"bar"
+                )
+            )
+        else:
+            self.data = data
+
+        self._make_zip(destfile)
+        self.destfile = destfile
+
+    def content(self, path):
+        d = self.data
+
+        for node in path.split(os.path.sep):
+            print(node)
+            d = d.get(node)
+            if not isinstance(d, dict):
+                return d
+
+    def _make_zip(self, destfile):
+        with ZipFile(destfile, "w") as z:
+            stack = []
+            self._write_zip_contents(z, stack, self.data)
+
+    def _write_zip_contents(self, z, stack, data):
+        for k in data:
+            if isinstance(data[k], dict):
+                self._write_zip_contents(z, stack+[k], data[k])
+            else:
+                path = os.path.join(*stack, k)
+                with z.open(path, 'w') as fp:
+                    fp.write(data[k])
+
+
+def make_zip(zipfilename, root_dir, base_dir):
+    pwd = os.getcwd()
+    with ZipFile(zipfilename, "w") as f:
+        try:
+            os.chdir(root_dir)
+            for root, dirs, filenames in os.walk(base_dir):
+                for _dir in dirs:
+                    path = os.path.normpath(os.path.join(root, _dir))
+                    f.write(path)
+                for _file in filenames:
+                    path = os.path.normpath(os.path.join(root, _file))
+                    f.write(path)
+        finally:
+            os.chdir(pwd)
+
+
+def make_random_str(n):
+    return ''.join([random.choice(string.ascii_letters + string.digits)
+                    for i in range(n)])

--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -30,8 +30,7 @@ Or::
 
 from .hdfs import Hdfs, HdfsFileStat  # NOQA
 from .local import Local, LocalFileStat  # NOQA
+from .s3 import S3  # NOQA
 from .zip import Zip, ZipFileStat  # NOQA
-
-# from .s3 import S3
 
 local = Local()

--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -1,0 +1,37 @@
+'''
+fs.FS> interface
+implementations:
+open_fs(URI, container=None|zip) => Local/HDFS/S3/Zip, etc
+- Local
+  - subfs() -> Local
+  - open_zip() -> Zip
+  - open() -> FileObject
+- HDFS
+  - subfs() -> HDFS
+  - open_zip() -> Zip
+  - open() -> FileObject
+- Zip
+  - subfs() -> Zip
+  - open_zip() -> Zip
+  - open() -> FileObject
+- S3 (TBD)
+- GS (TBD)
+
+For example of globally switching backend file systems::
+
+  from pfio.v2 import local as pfio
+
+Or::
+
+  from pfio.v2 import Hdfs
+  pfio = Hdfs()
+
+'''
+
+from .hdfs import Hdfs, HdfsFileStat  # NOQA
+from .local import Local, LocalFileStat  # NOQA
+from .zip import Zip, ZipFileStat  # NOQA
+
+# from .s3 import S3
+
+local = Local()

--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -27,7 +27,7 @@ Or::
   pfio = Hdfs()
 
 '''
-from .fs import open_url  # NOQA
+from .fs import from_url, lazify, open_url  # NOQA
 from .hdfs import Hdfs, HdfsFileStat  # NOQA
 from .local import Local, LocalFileStat  # NOQA
 from .s3 import S3  # NOQA

--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -27,7 +27,7 @@ Or::
   pfio = Hdfs()
 
 '''
-
+from .fs import open_url  # NOQA
 from .hdfs import Hdfs, HdfsFileStat  # NOQA
 from .local import Local, LocalFileStat  # NOQA
 from .s3 import S3  # NOQA

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -1,0 +1,265 @@
+import abc
+import copy
+import os
+import stat
+from abc import abstractmethod
+from io import IOBase
+from types import TracebackType
+from typing import Any, Callable, Iterator, Optional, Type
+
+
+def open_wrapper(func):
+    def wrapper(self, file_path: str, mode: str = 'rb',
+                buffering: int = -1, encoding: Optional[str] = None,
+                errors: Optional[str] = None, newline: Optional[str] = None,
+                closefd: bool = True,
+                opener: Optional[Callable[
+                    [str, int], Any]] = None) -> Type['IOBase']:
+        file_obj = func(self, file_path, mode, buffering, encoding,
+                        errors, newline, closefd, opener)
+
+        if not hasattr(self, '_wrap_fileobject'):
+            return file_obj
+
+        return self._wrap_fileobject(
+            file_obj, file_path, mode, buffering, encoding,
+            errors, newline, closefd, opener)
+    return wrapper
+
+
+class FileStat(abc.ABC):
+    """Detailed file or directory information abstraction
+
+    :meth:`pfio.IO.stat` of filesystem/container handlers return an object of
+    subclass of ``FileStat``.
+    In addition to the common attributes that the ``FileStat`` abstract
+    provides, each ``FileStat`` subclass implements some additional
+    attributes depending on what information the corresponding filesystem or
+    container can handle.
+    The common attributes have the same behavior despite filesystem or
+    container type difference.
+
+    Attributes:
+        filename (str):
+            Filename in the filesystem or container.
+        last_modifled (float):
+            UNIX timestamp of mtime. Note that some
+            filesystems or containers do not have sub-second precision.
+        mode (int):
+            Permission with file type flag (regular file or directory).
+            You can make a human-readable interpretation by
+            `stat.filemode <https://docs.python.org/3/library/stat.html#stat.filemode>`_.
+        size (int):
+            Size in bytes. Note that directories may have different
+            sizes depending on the filesystem or container type.
+    """     # NOQA
+    filename = None
+    last_modified = None
+    mode = None
+    size = None
+
+    def isdir(self):
+        """Returns whether the target is a directory, based on the permission flag
+
+        Returns:
+            `True` if directory, `False` otherwise.
+        """
+        return bool(self.mode & 0o40000)
+
+    def __str__(self):
+        return '<{} filename="{}" mode="{}">'.format(
+            type(self).__name__, self.filename, stat.filemode(self.mode))
+
+    def __repr__(self):
+        return str(self.__str__())
+
+
+class FS(abc.ABC):
+    cwd = None
+    _readonly = False
+
+    def __init__(self):
+        self.pid = os.getpid()
+
+    @abstractmethod
+    def open(self, file_path: str, mode: str = 'rb',
+             buffering: int = -1, encoding: Optional[str] = None,
+             errors: Optional[str] = None,
+             newline: Optional[str] = None,
+             closefd: bool = True,
+             opener: Optional[Callable[
+                 [str, int], Any]] = None) -> Type["IOBase"]:
+        raise NotImplementedError()
+
+    def open_zip(self, file_path: str, mode='r') -> Type["Zip"]: # NOQA
+        from .zip import Zip
+        return Zip(self, file_path, mode)
+
+    def subfs(self, rel_path: str) -> Type["FS"]:
+        # By default it performs shallow copy. If any resource that
+        # has different lifecycles than the copy source (e.g. HDFS
+        # connection and zipfile.ZipFile object), they also must be
+        # copied.
+        sub = copy.copy(self)
+        sub.cwd = os.path.join(self.cwd, rel_path)
+        return sub
+
+    # TODO(kuenishi): add readonly property check to all
+    # implementations.
+    @property
+    def readonly(self):
+        return self._readonly
+
+    @readonly.setter
+    def readonly(self, val):
+        self._readonly = val
+
+    def _checkfork(self):
+        if self.is_forked:
+            raise RuntimeError("Process fork detected.")
+
+    @property
+    def is_forked(self):
+        return self.pid != os.getpid()
+
+    def close(self) -> None:
+        pass
+
+    @abstractmethod
+    def list(self, path_or_prefix: Optional[str] = None,
+             recursive=False) -> Iterator[str]:
+        """Lists all the files and directories under
+           the given ``path_or_prefix``
+
+        Args:
+            path_or_prefix (str): The path to list against.
+                When we get the default value, ``list`` shows the content under
+                the root path, as the default value.
+                Refer to :func:`set_root` for details about the root path of
+                each filesystem. However, if a ``path_or_prefix`` is given,
+                then it shows only the files and directories
+                under the ``path_or_prefix``.
+
+            recursive (bool): When this is ``True``, list files and directories
+                recursively.
+
+        Returns:
+            An Iterator that iterates though the files and directories.
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def stat(self, path: str) -> FileStat:
+        """Show details of a file
+
+        It returns an object of subclass of :class:`pfio.io.FileStat`
+        in accordance with filesystem or container type.
+
+        Args:
+            path (str): The path to file
+
+        Returns:
+            :class:`pfio.io.FileStat` object.
+        """
+        raise NotImplementedError()
+
+    def __enter__(self) -> 'FS':
+        return self
+
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> bool:
+        self.close()
+
+    @abstractmethod
+    def isdir(self, file_path: str) -> bool:
+        """Returns ``True`` if the path is an existing directory
+
+        Args:
+            path (str): the path to the target directory
+
+        Returns:
+            ``True`` when the path points to a directory,
+            ``False`` when it is not
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def mkdir(self, file_path: str, mode: int = 0o777,
+              *args, dir_fd: Optional[int] = None) -> None:
+        """Makes a directory with mode
+
+        Args:
+            path (str): the path to the directory to make
+
+            mode (int): the mode of the new directory
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def makedirs(self, file_path: str, mode: int = 0o777,
+                 exist_ok: bool = False) -> None:
+        """Makes directories recursively with mode
+
+        Also creates all the missing parents of the given path.
+
+        Args:
+            path (str): the path to the directory to make.
+
+            mode (int): the mode of the directory
+
+            exist_ok (bool): In default case, a ``FileExitsError`` will be
+                raised when the target directory exists.
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def exists(self, file_path: str) -> bool:
+        """Returns ``True`` when the given ``path`` exists
+
+        When the ``file_path`` points to a symlink, the return value
+        depends on the actual file instead of the link itself.
+
+        Args:
+            path (str): the ``path`` to the target file. The ``path`` can be a
+            POSIX path or a URI.
+
+        Returns:
+            ``True`` when the file or directory exists,
+            ``False`` when it is not.
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def rename(self, src: str, dst: str) -> None:
+        """Renames the file from ``src`` to ``dst``
+
+        Args:
+            src (str): the current name of the file or directory.
+
+            dst (str): the name to rename to.
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def remove(self, file_path: str, recursive: bool = False) -> None:
+        """Removes a file or directory
+
+           A combination of :func:`os.remove` and :func:`os.rmtree`.
+
+           Args:
+               path (str): the target path to remove. The ``path`` can be a
+               regular file or a directory.
+
+               recursive (bool): When the given path is a directory,
+                   all the files and directories under it will be removed.
+                   When the path is a file, this option is ignored.
+
+        """
+        raise NotImplementedError()

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -44,6 +44,8 @@ class FileStat(abc.ABC):
     def isdir(self):
         """Returns whether the target is a directory, based on the permission flag
 
+        Note that some systems do not support directory tree semantics.
+
         Returns:
             `True` if directory, `False` otherwise.
         """
@@ -125,9 +127,8 @@ class FS(abc.ABC):
         Args:
             path_or_prefix (str): The path to list against.
                 When we get the default value, ``list`` shows the content under
-                the root path, as the default value.
-                Refer to :func:`set_root` for details about the root path of
-                each filesystem. However, if a ``path_or_prefix`` is given,
+                the working directory as the default value.
+                However, if a ``path_or_prefix`` is given,
                 then it shows only the files and directories
                 under the ``path_or_prefix``.
 
@@ -209,19 +210,11 @@ class FS(abc.ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def exists(self, file_path: str) -> bool:
-        """Returns ``True`` when the given ``path`` exists
+    def exists(self, path: str) -> bool:
+        """Returns the existence of the path
 
         When the ``file_path`` points to a symlink, the return value
         depends on the actual file instead of the link itself.
-
-        Args:
-            path (str): the ``path`` to the target file. The ``path`` can be a
-            POSIX path or a URI.
-
-        Returns:
-            ``True`` when the file or directory exists,
-            ``False`` when it is not.
 
         """
         raise NotImplementedError()
@@ -229,6 +222,10 @@ class FS(abc.ABC):
     @abstractmethod
     def rename(self, src: str, dst: str) -> None:
         """Renames the file from ``src`` to ``dst``
+
+        On systems and situation where rename functionality is
+        proviced, it renames the file or the directory.
+
 
         Args:
             src (str): the current name of the file or directory.
@@ -241,8 +238,6 @@ class FS(abc.ABC):
     @abstractmethod
     def remove(self, file_path: str, recursive: bool = False) -> None:
         """Removes a file or directory
-
-           A combination of :func:`os.remove` and :func:`os.rmtree`.
 
            Args:
                path (str): the target path to remove. The ``path`` can be a

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -87,7 +87,7 @@ class FS(abc.ABC):
         return Zip(self, file_path, mode)
 
     def subfs(self, rel_path: str) -> Type["FS"]:
-        '''Virtually changes the working directory 
+        '''Virtually changes the working directory
 
         By default it performs shallow copy. If any resource that as
         different lifecycles than the copy source (e.g. HDFS

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -62,6 +62,10 @@ class ForkedError(RuntimeError):
 
 
 class FS(abc.ABC):
+    '''FS access abstraction
+
+    '''
+
     cwd = None
     pid = os.getpid()
 
@@ -83,10 +87,14 @@ class FS(abc.ABC):
         return Zip(self, file_path, mode)
 
     def subfs(self, rel_path: str) -> Type["FS"]:
-        # By default it performs shallow copy. If any resource that
-        # has different lifecycles than the copy source (e.g. HDFS
-        # connection and zipfile.ZipFile object), they also must be
-        # copied.
+        '''Virtually changes the working directory 
+
+        By default it performs shallow copy. If any resource that as
+        different lifecycles than the copy source (e.g. HDFS
+        connection and zipfile.ZipFile object), they also will be
+        copied by overriding this method.
+
+        '''
         sub = copy.copy(self)
         if self.cwd is not None:
             sub.cwd = os.path.join(self.cwd, rel_path)
@@ -255,7 +263,7 @@ def open_url(url: str, mode: str = 'r') -> 'IOBase':
            f.read()
 
     .. note:: Some FS resouces won't be closed when using this
-    functionality.
+        functionality.
 
     Returns:
         a FileObject that must be closed.
@@ -271,7 +279,7 @@ def from_url(url: str) -> 'FS':
     '''Factory pattern implementation, creates FS from URI
 
     .. note:: Some FS resouces won't be closed when using this
-    functionality.
+        functionality.
 
     '''
     parsed = urlparse(url)

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -95,6 +95,11 @@ class FS(abc.ABC):
         copied by overriding this method.
 
         '''
+        if rel_path.startswith("/"):
+            raise RuntimeError("Absolute path is not supported")
+        elif '..' in rel_path.split(os.path.sep):
+            raise RuntimeError("Only subtree is supported")
+
         sub = copy.copy(self)
         if self.cwd is not None:
             sub.cwd = os.path.join(self.cwd, rel_path)
@@ -303,10 +308,9 @@ def from_url(url: str) -> 'FS':
     elif scheme == 's3':
         from .s3 import S3
 
-        # TODO: how can we handle access keys?
-        fs = S3(bucket=parsed.netloc,
+        fs = S3(bucket=parsed.netloc, key=dirname,
                 endpoint=os.getenv('S3_ENDPOINT'))
-        fs = fs.subfs(dirname)
+
     else:
         raise RuntimeError("Scheme {} is not supported", scheme)
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -13,12 +13,11 @@ from urllib.parse import urlparse
 class FileStat(abc.ABC):
     """Detailed file or directory information abstraction
 
-    :meth:`pfio.IO.stat` of filesystem/container handlers return an object of
-    subclass of ``FileStat``.
-    In addition to the common attributes that the ``FileStat`` abstract
-    provides, each ``FileStat`` subclass implements some additional
-    attributes depending on what information the corresponding filesystem or
-    container can handle.
+    :meth:`pfio.v2.FS.stat` returns an object that implements of
+    ``FileStat``.  In addition to the common attributes that the
+    ``FileStat`` abstract provides, each ``FileStat`` subclass
+    implements some additional attributes depending on what
+    information the corresponding filesystem or container can handle.
     The common attributes have the same behavior despite filesystem or
     container type difference.
 
@@ -35,6 +34,7 @@ class FileStat(abc.ABC):
         size (int):
             Size in bytes. Note that directories may have different
             sizes depending on the filesystem or container type.
+
     """     # NOQA
     filename = None
     last_modified = None
@@ -308,7 +308,7 @@ def from_url(url: str) -> 'FS':
     elif scheme == 's3':
         from .s3 import S3
 
-        fs = S3(bucket=parsed.netloc, key=dirname,
+        fs = S3(bucket=parsed.netloc, prefix=dirname,
                 endpoint=os.getenv('S3_ENDPOINT'))
 
     else:

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -8,25 +8,6 @@ from types import TracebackType
 from typing import Any, Callable, Iterator, Optional, Type
 
 
-def open_wrapper(func):
-    def wrapper(self, file_path: str, mode: str = 'rb',
-                buffering: int = -1, encoding: Optional[str] = None,
-                errors: Optional[str] = None, newline: Optional[str] = None,
-                closefd: bool = True,
-                opener: Optional[Callable[
-                    [str, int], Any]] = None) -> Type['IOBase']:
-        file_obj = func(self, file_path, mode, buffering, encoding,
-                        errors, newline, closefd, opener)
-
-        if not hasattr(self, '_wrap_fileobject'):
-            return file_obj
-
-        return self._wrap_fileobject(
-            file_obj, file_path, mode, buffering, encoding,
-            errors, newline, closefd, opener)
-    return wrapper
-
-
 class FileStat(abc.ABC):
     """Detailed file or directory information abstraction
 

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -173,8 +173,6 @@ class Hdfs(FS):
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):
 
-        self._create_connection()
-
         # hdfs only support open in 'b'
         if 'b' not in mode:
             mode += 'b'

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -1,0 +1,245 @@
+import getpass
+import io
+import logging
+import os
+import re
+import subprocess
+from io import IOBase
+from typing import Any, Callable, Type
+
+import pyarrow
+from pyarrow import hdfs
+
+from pfio._typing import Optional
+
+from .fs import FS, FileStat, open_wrapper
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+
+
+def _parse_principal_name_from_klist(output):
+    output_array = output.split('\n')
+    if len(output_array) < 2:
+        return None
+
+    principle_str = output_array[1]
+    klist_principal_pattern = re.compile(
+        r'Default principal: (?P<username>.+)@(?P<service>.+)')
+    ret = klist_principal_pattern.match(principle_str)
+    if ret:
+        pattern_dict = ret.groupdict()
+        return pattern_dict['username']
+    else:
+        return None
+
+
+def _parse_principal_name_from_keytab(output):
+    output_array = output.split('\n')
+    if len(output_array) < 4:
+        return None
+
+    principle_str = output_array[3]
+    keytab_principle_pattern = re.compile(
+        r'\s+\d+ (?P<username>.+)@(?P<service>.+)')
+    ret = keytab_principle_pattern.match(principle_str)
+    if ret:
+        pattern_dict = ret.groupdict()
+        return pattern_dict['username']
+    else:
+        return None
+
+
+def _get_principal_name_from_keytab():
+    output = _run_klist(use_keytab=True)
+    if output is None:
+        return None
+
+    return _parse_principal_name_from_keytab(output.decode('utf-8'))
+
+
+def _get_principal_name_from_klist():
+    output = _run_klist()
+    if output is None:
+        return None
+    return _parse_principal_name_from_klist(output.decode('utf-8'))
+
+
+def _run_klist(use_keytab=False):
+    try:
+        command = ['klist']
+        if use_keytab:
+            command += ['-k']
+        pipe = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        out, err = pipe.communicate()
+        if out == b'' and err != b'':
+            return None
+        else:
+            return out
+    except OSError:
+        # klist is not found
+        return None
+
+
+class HdfsFileStat(FileStat):
+    """Detailed information of a file in HDFS
+
+    Attributes:
+        filename (str): Derived from `~FileStat`.
+        last_modifled (float): Derived from `~FileStat`.
+            No sub-second precision.
+        last_accessed (float): UNIX timestamp of last access time.
+            No sub-second precision.
+        mode (int): Derived from `~FileStat`.
+        size (int): Derived from `~FileStat`.
+        owner (str): Owner of the file. Unlike `~PosixFileStat.owner`,
+            this is a user name string instead of an integer.
+        group (str): Group of the file in string.
+        replication (int): Number of replications of the file in HDFS.
+        block_size (int): Block size in bytes.
+        kind (str): Group of the file in string.
+    """
+
+    def __init__(self, info):
+        mode = info['permissions']
+        if info['kind'] == 'file':
+            mode |= 0o100000
+        elif info['kind'] == 'directory':
+            mode |= 0o40000
+
+        self.filename = info['path']
+        self.mode = mode
+        self.last_modified = float(info['last_modified'])
+        self.last_accessed = float(info['last_accessed'])
+        for k in ('size', 'owner', 'group', 'replication',
+                  'block_size', 'kind'):
+            setattr(self, k, info[k])
+
+
+class Hdfs(FS):
+    def __init__(self, cwd=None):
+        super().__init__()
+        self.connection = hdfs.connect()
+        assert self.connection is not None
+        self.cwd = cwd
+        self.username = self._get_principal_name()
+
+        # set nameservice
+        _file_in_root = self.connection.ls("/")[0]
+        self.nameservice = _file_in_root[:_file_in_root.rfind("/")]
+
+    def _get_principal_name(self):
+        # get the default principal name from `klist` cache
+        principal_name = _get_principal_name_from_klist()
+
+        if principal_name is not None:
+            return principal_name
+
+        # try getting principal name from keytab
+        principal_name = _get_principal_name_from_keytab()
+        if principal_name is not None:
+            return principal_name
+
+        # in case every thing, use the login username instead
+        return self._get_login_username()
+
+    def _get_login_username(self):
+        return getpass.getuser()
+
+    def _wrap_fileobject(self, file_obj: Type['IOBase'],
+                         file_path: str, mode: str = 'rb',
+                         buffering: int = -1,
+                         encoding: Optional[str] = None,
+                         errors: Optional[str] = None,
+                         newline: Optional[str] = None,
+                         closefd: bool = True,
+                         opener: Optional[Callable[
+                             [str, int], Any]] = None) -> Type['IOBase']:
+
+        if 'b' not in mode:
+            file_obj = io.TextIOWrapper(file_obj, encoding, errors, newline)
+        elif 'r' in mode:
+            # Wrapping file_obj with io.BufferedReader to add `peek` support,
+            # which signiciantly improves unpickle performance.
+            file_obj = io.BufferedReader(file_obj)
+        else:
+            file_obj = io.BufferedWriter(file_obj)
+
+        return file_obj
+
+    @open_wrapper
+    def open(self, file_path, mode='rb',
+             buffering=-1, encoding=None, errors=None,
+             newline=None, closefd=True, opener=None):
+
+        self._create_connection()
+
+        # hdfs only support open in 'b'
+        if 'b' not in mode:
+            mode += 'b'
+        try:
+            hdfs_file = self.connection.open(file_path, mode)
+            return hdfs_file
+        except pyarrow.lib.ArrowIOError as e:
+            raise IOError("open file error :{}".format(str(e)))
+
+    def subfs(self, rel_path):
+        return Hdfs(os.path.join(self.cwd, rel_path))
+
+    def close(self):
+        self.connection.close()
+
+    def list(self, path_or_prefix: str = None, recursive=False):
+        if path_or_prefix is None:
+            path_or_prefix = "/user/{}".format(self.username)
+
+        target_dir = self.connection.info(path_or_prefix)
+        if target_dir['kind'] != "directory":
+            raise NotADirectoryError(path_or_prefix)
+
+        target_dir_path = target_dir['path']
+        # +1 to include the "/"
+        full_uri_prefix_offset = len(target_dir_path) + 1
+
+        if recursive:
+            yield from self._recursive_list(full_uri_prefix_offset,
+                                            path_or_prefix)
+        else:
+            dir_list = self.connection.ls(path_or_prefix)
+            for _dir in dir_list:
+                yield os.path.basename(_dir)
+
+    def _recursive_list(self, full_uri_prefix_offset, path):
+        for _file in self.connection.ls(path, detail=True):
+            file_name = _file['name']
+            # convert the full URI to relative path from path_or_prefix
+            # to align with posix
+            # e.g. "hdfs://nameservice/prefix_dir/testfile"
+            # => "testfile"
+            yield file_name[full_uri_prefix_offset:]
+
+            if 'directory' == _file['kind']:
+                yield from self._recursive_list(full_uri_prefix_offset,
+                                                file_name)
+
+    def stat(self, path):
+        return HdfsFileStat(self.connection.info(path))
+
+    def isdir(self, file_path: str):
+        return self.stat(file_path).isdir()
+
+    def mkdir(self, file_path: str, *args, dir_fd=None):
+        return self.connection.mkdir(file_path)
+
+    def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
+        return self.mkdir(file_path, mode, exist_ok)
+
+    def exists(self, file_path: str):
+        return self.connection.exists(file_path)
+
+    def rename(self, src, dst):
+        return self.connection.rename(src, dst)
+
+    def remove(self, path, recursive=False):
+        return self.connection.delete(path, recursive)

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -146,7 +146,7 @@ class Hdfs(FS):
     def open(self, file_path, mode='rb',
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):
-
+        self._checkfork()
         orig_mode = mode
 
         # hdfs only support open in 'b'
@@ -173,9 +173,11 @@ class Hdfs(FS):
         return Hdfs(os.path.join(self.cwd, rel_path))
 
     def close(self):
+        self._checkfork()
         self.connection.close()
 
     def list(self, path_or_prefix: str = None, recursive=False):
+        self._checkfork()
         if path_or_prefix is None:
             path_or_prefix = "/user/{}".format(self.username)
 
@@ -209,22 +211,27 @@ class Hdfs(FS):
                                                 file_name)
 
     def stat(self, path):
+        self._checkfork()
         return HdfsFileStat(self.connection.info(path))
 
     def isdir(self, file_path: str):
         return self.stat(file_path).isdir()
 
     def mkdir(self, file_path: str, *args, dir_fd=None):
+        self._checkfork()
         return self.connection.mkdir(file_path)
 
     def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
         return self.mkdir(file_path, mode, exist_ok)
 
     def exists(self, file_path: str):
+        self._checkfork()
         return self.connection.exists(file_path)
 
     def rename(self, src, dst):
+        self._checkfork()
         return self.connection.rename(src, dst)
 
     def remove(self, path, recursive=False):
+        self._checkfork()
         return self.connection.delete(path, recursive)

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -45,10 +45,14 @@ class LocalFileStat(FileStat):
 class Local(FS):
     def __init__(self, cwd=None):
         super().__init__()
-        if cwd is None:
-            self.cwd = os.getcwd()
+        self._cwd = None
+
+    @property
+    def cwd(self):
+        if self._cwd is None:
+            return os.getcwd()
         else:
-            self.cwd = cwd
+            return self._cwd
 
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -1,0 +1,109 @@
+import io
+import os
+import shutil
+
+from .fs import FS, FileStat, open_wrapper
+
+
+class LocalFileStat(FileStat):
+    """Detailed information of a POSIX file
+
+    The information of file/directory is obtained through the `os.stat`.
+
+    Attributes:
+        filename (str): Derived from `~FileStat`.
+        last_modified (float): Derived from `~FileStat`.
+            ``os.stat_result.st_mtime``.
+        last_accessed (float): ``os.stat_result.st_atime``.
+        created (float): ``os.stat_result.st_ctime``.
+        last_modified_ns (int): ``os.stat_result.st_mtime_ns``.
+        last_accessed_ns (int): ``os.stat_result.st_atime_ns``.
+        created_ns (float): ``os.stat_result.st_ctime``.
+        mode (int): Derived from `~FileStat`. ``os.stat_result.st_mode``.
+        size (int): Derived from `~FileStat`. ``os.stat_result.st_size``.
+        owner (int): UID of owner in integer.
+        group (int): GID of the file in integer.
+        inode (int): ``os.stat_result.st_ino``.
+        device (int): ``os.stat_result.st_dev``.
+        nlink (int): ``os.stat_result.st_nlink``.
+    """
+
+    def __init__(self, _stat, filename):
+        keys = (('last_modified', 'st_mtime'),
+                ('last_accessed', 'st_atime'),
+                ('last_modified_ns', 'st_mtime_ns'),
+                ('last_accessed_ns', 'st_atime_ns'),
+                ('created', 'st_ctime'), ('created_ns', 'st_ctime_ns'),
+                ('mode', 'st_mode'), ('size', 'st_size'), ('uid', 'st_uid'),
+                ('gid', 'st_gid'), ('ino', 'st_ino'), ('dev', 'st_dev'),
+                ('nlink', 'st_nlink'))
+        for k, ksrc in keys:
+            setattr(self, k, getattr(_stat, ksrc))
+        self.filename = filename
+
+
+class Local(FS):
+    def __init__(self, cwd=None):
+        super().__init__()
+        if cwd is None:
+            self.cwd = os.getcwd()
+        else:
+            self.cwd = cwd
+
+    @open_wrapper
+    def open(self, file_path, mode='r',
+             buffering=-1, encoding=None, errors=None,
+             newline=None, closefd=True, opener=None):
+
+        return io.open(file_path, mode,
+                       buffering, encoding, errors,
+                       newline, closefd, opener)
+
+    def subfs(self, rel_path):
+        raise NotImplementedError()
+
+    def list(self, path_or_prefix: str = None, recursive=False):
+        if path_or_prefix is None:
+            path_or_prefix = self.cwd
+        if recursive:
+            path_or_prefix = path_or_prefix.rstrip("/")
+            # plus 1 to include the trailing slash
+            prefix_end_index = len(path_or_prefix) + 1
+            yield from self._recursive_list(prefix_end_index, path_or_prefix)
+        else:
+            for file in os.scandir(path_or_prefix):
+                yield file.name
+
+    def _recursive_list(self, prefix_end_index: int, path: str):
+        for file in os.scandir(path):
+            yield file.path[prefix_end_index:]
+
+            if file.is_dir():
+                yield from self._recursive_list(prefix_end_index,
+                                                file.path)
+
+    def stat(self, path):
+        return LocalFileStat(os.stat(path), path)
+
+    def isdir(self, file_path: str):
+        return os.path.isdir(file_path)
+
+    def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
+        return os.mkdir(file_path, mode, *args, dir_fd=None)
+
+    def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
+        return os.makedirs(file_path, mode, exist_ok)
+
+    def exists(self, file_path: str):
+        return os.path.exists(file_path)
+
+    def rename(self, src, dst):
+        return os.rename(src, dst)
+
+    def remove(self, file_path: str, recursive=False):
+        if recursive:
+            return shutil.rmtree(file_path)
+        if os.path.isdir(file_path):
+            return os.rmdir(file_path)
+
+        return os.remove(file_path)

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -45,7 +45,10 @@ class LocalFileStat(FileStat):
 class Local(FS):
     def __init__(self, cwd=None):
         super().__init__()
-        self._cwd = None
+        if cwd is None:
+            self._cwd = None
+        else:
+            self._cwd = cwd
 
     @property
     def cwd(self):

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -2,7 +2,7 @@ import io
 import os
 import shutil
 
-from .fs import FS, FileStat, open_wrapper
+from .fs import FS, FileStat
 
 
 class LocalFileStat(FileStat):
@@ -50,12 +50,12 @@ class Local(FS):
         else:
             self.cwd = cwd
 
-    @open_wrapper
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):
 
-        return io.open(file_path, mode,
+        path = os.path.join(self.cwd, file_path)
+        return io.open(path, mode,
                        buffering, encoding, errors,
                        newline, closefd, opener)
 
@@ -101,6 +101,7 @@ class Local(FS):
         return os.rename(src, dst)
 
     def remove(self, file_path: str, recursive=False):
+        file_path = os.path.join(self.cwd, file_path)
         if recursive:
             return shutil.rmtree(file_path)
         if os.path.isdir(file_path):

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -13,11 +13,11 @@ class _ObjectReader(io.BufferedReader):
         self.client = client
         self.res = self.client.get_object(Bucket=bucket,
                                           Key=key)
-        self.mode = mode
+        self._mode = mode
         self.body = self.res['Body']
 
     def read(self):
-        if 'b' in self.mode:
+        if 'b' in self._mode:
             return self.body.read()
         else:
             return self.body.read().decode('utf-8')

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -98,6 +98,7 @@ class S3(FS):
             raise RuntimeError(f'Unknown option: {mode}')
 
     def list(self, prefix: str = None, recursive=False):
+        self._checkfork()
         # TODO: recursive list
         res = self.client.list_objects_v2(Bucket=self.bucket)
         print(res['Name'])
@@ -107,6 +108,7 @@ class S3(FS):
                 yield k
 
     def stat(self, path):
+        self._checkfork()
         raise NotImplementedError()
         # return FileStat(os.stat(path), path)
 
@@ -120,6 +122,7 @@ class S3(FS):
         raise os.UnsupportedOperation("S3 doesn't have directory")
 
     def exists(self, file_path: str):
+        self._checkfork()
         raise NotImplementedError()
 
     def rename(self, src, dst):
@@ -129,5 +132,6 @@ class S3(FS):
         if recursive:
             raise os.UnsupportedOperation("Recursive delete not supported")
 
+        self._checkfork()
         return self.client.delete_object(Bucket=self.bucket,
                                          Key=file_path)

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -1,0 +1,71 @@
+import os
+import shutil
+
+import boto3
+
+from .fs import FS, open_wrapper
+
+
+class S3(FS):
+    def __init__(self, bucket=None, endpoint=None):
+        self.bucket = bucket
+        self.endpoint = endpoint
+
+        # boto3.set_stream_logger()
+
+        # import botocore
+        # botocore.session.Session().set_debug_logger()
+
+        # if 'AWS_ACCESS_KEY_ID' in os.getenv():
+        # aws_access_key_id='me@EXAMPLE.COM',
+        # aws_secret_access_key='XXXXXXX',
+        kwargs = {}
+        if endpoint is not None:
+            kwargs['endpoint_url'] = endpoint
+
+        self.client = boto3.client('s3', *kwargs)
+
+    @open_wrapper
+    def open(self, file_path, mode='r',
+             buffering=-1, encoding=None, errors=None,
+             newline=None, closefd=True, opener=None):
+        raise NotImplementedError()
+
+    def subfs(self, rel_path):
+        raise NotImplementedError()
+
+    def list(self, prefix: str = None, recursive=False):
+        # TODO: recursive list
+        res = self.client.list_objects_v2(Bucket=self.bucket)
+        print(res['Name'])
+        # kc = res['KeyCount']
+        if 'Contents' in res:
+            for k in res['Contents']:
+                yield k
+
+    def stat(self, path):
+        raise NotImplementedError()
+        # return FileStat(os.stat(path), path)
+
+    def isdir(self, file_path: str):
+        raise os.UnsupportedOperation("S3 doesn't have directory")
+
+    def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
+        raise os.UnsupportedOperation("S3 doesn't have directory")
+
+    def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
+        raise os.UnsupportedOperation("S3 doesn't have directory")
+
+    def exists(self, file_path: str):
+        raise NotImplementedError()
+
+    def rename(self, src, dst):
+        raise os.UnsupportedOperation("S3 doesn't support rename")
+
+    def remove(self, file_path: str, recursive=False):
+        if recursive:
+            return shutil.rmtree(file_path)
+        if os.path.isdir(file_path):
+            return os.rmdir(file_path)
+
+        return os.remove(file_path)

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -97,9 +97,6 @@ class S3(FS):
         else:
             raise RuntimeError(f'Unknown option: {mode}')
 
-    def subfs(self, rel_path):
-        raise NotImplementedError()
-
     def list(self, prefix: str = None, recursive=False):
         # TODO: recursive list
         res = self.client.list_objects_v2(Bucket=self.bucket)

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -65,9 +65,12 @@ class _ObjectWriter(io.BufferedWriter):
 
 
 class S3(FS):
-    def __init__(self, bucket=None, endpoint=None):
+    def __init__(self, bucket=None, key=None,
+                 endpoint=None,):
         self.bucket = bucket
         self.endpoint = endpoint
+        if key is not None:
+            self.cwd = key
 
         # boto3.set_stream_logger()
 

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -55,6 +55,8 @@ class Zip(FS):
     def __init__(self, backend, file_path, mode='r'):
         super().__init__()
         self.backend = backend
+        self.file_path = file_path
+        self.mode = mode
 
         if 'w' in mode:
             self._readonly = False
@@ -101,8 +103,12 @@ class Zip(FS):
         return fp
 
     def close(self):
+        self._checkfork()
         self.zipobj.close()
         self.fileobj.close()
+
+    def subfs(self):
+        return Zip(self.backend, self.file_path, self.mode)
 
     def stat(self, path):
         self._checkfork()

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -1,0 +1,205 @@
+import io
+import logging
+import os
+import sys
+import warnings
+import zipfile
+from datetime import datetime
+
+from .fs import FS, FileStat, open_wrapper
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+
+
+class ZipFileStat(FileStat):
+    """Detailed information of a file in a Zip
+
+    Attributes:
+        filename (str): Derived from `~FileStat`.
+        orig_filename (str): ``ZipFile.orig_filename``.
+        comment (str): ``ZipFile.comment``.
+        last_modifled (float): Derived from `~FileStat`.
+            No sub-second precision.
+        mode (int): Derived from `~FileStat`.
+        size (int): Derived from `~FileStat`.
+        create_system (int): ``ZipFile.create_system``.
+        create_version (int): ``ZipFile.create_version``.
+        extract_version (int): ``ZipFile.extract_version``.
+        flag_bits (int): ``ZipFile.flag_bits``.
+        volume (int): ``ZipFile.volume``.
+        internal_attr (int): ``ZipFile.internal_attr``.
+        external_attr (int): ``ZipFile.external_attr``.
+        header_offset (int): ``ZipFile.header_offset``.
+        compress_size (int): ``ZipFile.compress_size``.
+        compress_type (int): ``ZipFile.compress_type``.
+        CRC (int): ``ZipFile.CRC``.
+    """
+
+    def __init__(self, zip_info):
+        self.last_modified = float(datetime(*zip_info.date_time).timestamp())
+        # https://github.com/python/cpython/blob/3.8/Lib/zipfile.py#L392
+        self.mode = zip_info.external_attr >> 16
+        self.size = zip_info.file_size
+
+        for k in ('filename', 'orig_filename', 'comment', 'create_system',
+                  'create_version', 'extract_version', 'flag_bits',
+                  'volume', 'internal_attr', 'external_attr', 'CRC',
+                  'header_offset', 'compress_size', 'compress_type'):
+            setattr(self, k, getattr(zip_info, k))
+
+
+class Zip(FS):
+    _readonly = True
+
+    def __init__(self, backend, file_path, mode='r'):
+        super().__init__()
+        self.backend = backend
+
+        if 'w' in mode:
+            self._readonly = False
+
+        file_path = os.path.normpath(file_path)
+        self.fileobj = self.backend.open(file_path, mode + 'b')
+
+        if isinstance(self.backend, Zip) \
+           and sys.version_info < (3, 7, ):
+            # In Python < 3.7, the returned file object from zipfile.open,
+            # i.e. ZipExtFile, is not seekable,
+            # while in order to open as zip, the zipfile module requires
+            # the given file object to be seekable, which makes
+            # nested zip impossible.
+            # As a workaround, in case of nested zip,  we read the
+            # whole nested zipfile into BytesIO object,
+            # which is a seekable file object, upon open.
+            # However, it might cause performance and memory
+            # issues when the zipfile is huge. A warning is generated
+            # for user.
+
+            warnings.warn('In Python < 3.7, '
+                          'To support opening nested zip as container, '
+                          'PFIO has to read '
+                          'the entire nested zip upon open, '
+                          'which might cause performance or '
+                          'memory issues when the nested zip is huge.',
+                          category=RuntimeWarning)
+            self.fileobj = io.BytesIO(self.fileobj.read())
+
+        self.zipobj = zipfile.ZipFile(self.fileobj, mode)
+
+    @open_wrapper
+    def open(self, file_path, mode='r',
+             buffering=-1, encoding=None, errors=None,
+             newline=None, closefd=True, opener=None):
+        self._checkfork()
+
+        file_path = os.path.normpath(file_path)
+        fp = self.zipobj.open(file_path, mode.replace('b', ''))
+
+        if 'b' not in mode:
+            fp = io.TextIOWrapper(fp, encoding, errors, newline)
+
+        return fp
+
+    def close(self):
+        self.zipobj.close()
+        self.fileobj.close()
+
+    def stat(self, path):
+        self._checkfork()
+        path = os.path.normpath(path)
+        if path in self.zipobj.namelist():
+            actual_path = path
+        elif (not path.endswith('/')
+              and path + '/' in self.zipobj.namelist()):
+            # handles cases when path is a directory but without trailing slash
+            # see issue $67
+            actual_path = path + '/'
+        else:
+            raise FileNotFoundError(
+                "{} is not found".format(path))
+
+        return ZipFileStat(self.zipobj.getinfo(actual_path))
+
+    def list(self, path_or_prefix: str = "", recursive=False):
+        self._checkfork()
+        if path_or_prefix:
+            path_or_prefix = os.path.normpath(path_or_prefix)
+            # cannot move beyond root
+            given_dir_list = path_or_prefix.split('/')
+            if ("." in given_dir_list or ".." in given_dir_list
+                    or {""} == set(given_dir_list)):
+                given_dir_list = []
+                path_or_prefix = ""
+        else:
+            given_dir_list = []
+
+        if path_or_prefix:
+            if self.exists(path_or_prefix) and not self.isdir(path_or_prefix):
+                raise NotADirectoryError(
+                    "{} is not a directory".format(path_or_prefix))
+            elif not any(name.startswith(path_or_prefix + "/")
+                         for name in self.zipobj.namelist()):
+                # check if directories are NOT included in the zip
+                # such kind of zip can be made with "zip -D"
+                raise FileNotFoundError(
+                    "{} is not found".format(path_or_prefix))
+
+        if recursive:
+            for name in self.zipobj.namelist():
+                if name.startswith(path_or_prefix):
+                    name = name[len(path_or_prefix):].strip("/")
+                    if name:
+                        yield name
+        else:
+            _list = set()
+            for name in self.zipobj.namelist():
+                return_file_name = None
+                current_dir_list = os.path.normpath(name).split('/')
+                if not given_dir_list:
+                    # if path_or_prefix is not given
+                    return_file_name = current_dir_list[0]
+                else:
+                    if (current_dir_list
+                            and len(current_dir_list) > len(given_dir_list)
+                            and current_dir_list[:len(given_dir_list)] ==
+                            given_dir_list):
+                        return_file_name = current_dir_list[
+                            len(given_dir_list):][0]
+
+                if (return_file_name is not None
+                        and return_file_name not in _list):
+                    _list.add(return_file_name)
+                    yield return_file_name
+
+    def isdir(self, file_path: str):
+        self._checkfork()
+        if self.exists(file_path):
+            return self.stat(file_path).isdir()
+        else:
+            file_path = os.path.normpath(file_path)
+            # check if directories are NOT included in the zip
+            if any(name.startswith(file_path + "/")
+                   for name in self.zipobj.namelist()):
+                return True
+
+            return False
+
+    def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
+        raise io.UnsupportedOperation("zip does not support mkdir")
+
+    def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
+        raise io.UnsupportedOperation("zip does not support makedirs")
+
+    def exists(self, file_path: str):
+        self._checkfork()
+        file_path = os.path.normpath(file_path)
+        namelist = self.zipobj.namelist()
+        return (file_path in namelist
+                or file_path + "/" in namelist)
+
+    def rename(self, *args):
+        raise io.UnsupportedOperation
+
+    def remove(self, file_path, recursive=False):
+        raise io.UnsupportedOperation

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -6,7 +6,7 @@ import warnings
 import zipfile
 from datetime import datetime
 
-from .fs import FS, FileStat, open_wrapper
+from .fs import FS, FileStat
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -87,7 +87,6 @@ class Zip(FS):
 
         self.zipobj = zipfile.ZipFile(self.fileobj, mode)
 
-    @open_wrapper
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -58,6 +58,9 @@ class Zip(FS):
         self.file_path = file_path
         self.mode = mode
 
+        if 'r' in mode and 'w' in mode:
+            raise io.UnsupportedOperation('Read-write mode is not supported')
+
         if 'w' in mode:
             self._readonly = False
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.6",
-    install_requires=['pyarrow==3.0.0'],
+    install_requires=['pyarrow==3.0.0', 'boto3'],
     include_package_data=True,
     zip_safe=False,
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     package_data={'pfio': package_data},
-    extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort'],
+    extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.6",
     install_requires=['pyarrow==3.0.0'],

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -1,6 +1,6 @@
 # Test fs.FS compatibility
-import io
 import contextlib
+import io
 import multiprocessing as mp
 import os
 import random

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -10,7 +10,7 @@ from moto import mock_s3
 from parameterized import parameterized
 
 from pfio.testing import ZipForTest
-from pfio.v2 import S3, Local, fs, open_url
+from pfio.v2 import S3, Local, from_url, lazify, open_url
 
 
 def randstring():
@@ -47,11 +47,11 @@ def test_smoke(target):
 
 @mock_s3
 def test_factory_open():
-    assert isinstance(fs.from_url('.'), Local)
+    assert isinstance(from_url('.'), Local)
     with open_url('./setup.cfg') as fp:
         assert isinstance(fp, io.IOBase)
 
-    assert isinstance(fs.from_url('s3://foobar/boom/bom'), S3)
+    assert isinstance(from_url('s3://foobar/boom/bom'), S3)
     bucket = 'foobar'
     s3 = S3(bucket)
     s3.client.create_bucket(Bucket=bucket)
@@ -69,7 +69,7 @@ def test_recreate():
         z = ZipForTest(zipfilename)
         barrier = mp.Barrier(1)
 
-        with fs.recreate_on_fork(lambda: fs.from_url(zipfilename)) as f:
+        with lazify(lambda: from_url(zipfilename)) as f:
             with f.open('file', 'rb') as fp:
                 content = fp.read()
                 assert content

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -1,11 +1,12 @@
 # Test fs.FS compatibility
+import io
 import random
 import string
 
 from moto import mock_s3
 from parameterized import parameterized
 
-from pfio.v2 import S3, Local
+from pfio.v2 import S3, Local, fs, open_url
 
 
 def randstring():
@@ -38,3 +39,20 @@ def test_smoke(target):
             assert content == fp.read()
 
         fs.remove(filename)
+
+
+@mock_s3
+def test_factory_open():
+    assert isinstance(fs.from_url('.'), Local)
+    with open_url('./setup.cfg') as fp:
+        assert isinstance(fp, io.IOBase)
+
+    assert isinstance(fs.from_url('s3://foobar/boom/bom'), S3)
+    bucket = 'foobar'
+    s3 = S3(bucket)
+    s3.client.create_bucket(Bucket=bucket)
+    with open_url('s3://foobar/boom/bom.txt', 'w') as fp:
+        fp.write('hello')
+
+    with open_url('s3://foobar/boom/bom.txt', 'r') as fp:
+        assert 'hello' == fp.read()

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -1,0 +1,40 @@
+# Test fs.FS compatibility
+import random
+import string
+
+from moto import mock_s3
+from parameterized import parameterized
+
+from pfio.v2 import S3, Local
+
+
+def randstring():
+    letters = string.ascii_letters + string.digits
+    return (''.join(random.choice(letters) for _ in range(16)))
+
+
+def gen_fs(target):
+    if target == "s3":
+        bucket = "test-dummy-bucket"
+        s3 = S3(bucket)
+        s3.client.create_bucket(Bucket=bucket)
+        return s3
+    elif target == "local":
+        return Local("/tmp")
+    else:
+        raise RuntimeError()
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_smoke(target):
+    filename = randstring()
+    content = randstring()
+    with gen_fs(target) as fs:
+        with fs.open(filename, 'w') as fp:
+            fp.write(content)
+
+        with fs.open(filename, 'r') as fp:
+            assert content == fp.read()
+
+        fs.remove(filename)

--- a/tests/v2_tests/test_hdfs.py
+++ b/tests/v2_tests/test_hdfs.py
@@ -1,0 +1,321 @@
+import getpass
+import os
+import pickle
+import shutil
+import subprocess
+import tempfile
+import unittest
+from collections.abc import Iterable
+
+from pyarrow import hdfs
+
+from pfio.v2.hdfs import (Hdfs, HdfsFileStat, _get_principal_name_from_keytab,
+                          _get_principal_name_from_klist,
+                          _parse_principal_name_from_keytab,
+                          _parse_principal_name_from_klist)
+
+
+def create_dummy_keytab(tmpd, dummy_username):
+    dummy_password = "123"
+    keytab_path = os.path.join(tmpd, "user.keytab")
+    command = "(echo 'addent -password -p {}@{} -k 1 -e rc4-hmac' &&\
+              sleep 1 && echo {} && echo write_kt {}) \
+              | ktutil".format(dummy_username, "dummy_realm",
+                               dummy_password, keytab_path)
+    pipe = subprocess.Popen(command, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, shell=True)
+    out, err = pipe.communicate()
+    return keytab_path
+
+
+@unittest.skipIf(shutil.which('hdfs') is None, "HDFS client not installed")
+class TestHdfs(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_read_non_exist(self):
+        non_exist_file = "non_exist_file.txt"
+
+        with Hdfs() as fs:
+            self.assertRaises(IOError, fs.open, non_exist_file)
+
+    @unittest.skipIf(shutil.which('klist') is None, "klist not installed")
+    def test_get_principal_name(self):
+        original_krb5_ktname = os.environ.get('KRB5_KTNAME')
+
+        with Hdfs() as fs:
+            self.assertEqual(getpass.getuser(), fs._get_login_username())
+
+        dummy_username = "IAmADummy"
+        with tempfile.TemporaryDirectory() as tmpd:
+            try:
+                keytab_path = create_dummy_keytab(tmpd, dummy_username)
+                os.environ['KRB5_KTNAME'] = keytab_path
+                self.assertEqual(dummy_username,
+                                 _get_principal_name_from_keytab())
+
+            finally:
+                # put KRB5_KTNAME back
+                if original_krb5_ktname is None:
+                    del os.environ['KRB5_KTNAME']
+                else:
+                    os.environ['KRB5_KTNAME'] = original_krb5_ktname
+
+    def test_parse_principal_name_from_keytab(self):
+        username1 = 'fake_user1!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
+        username2 = 'fake_user2!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
+        service = 'fake_service!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
+        correct_out = 'Keytab name: FILE:user.keytab\n\
+                KVNO Principal\n---- ------------------\
+                --------------------------------------------------------\n\
+                1 {}@{} \n   2 {}@{}\n'.format(username1, service,
+                                               username2, service)
+        self.assertEqual(username1,
+                         (_parse_principal_name_from_keytab(
+                             correct_out)))
+
+    def test_parse_principal_name_from_klist(self):
+        username = 'fake_user!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
+        service = 'fake_service!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
+        correct_out = 'Ticket cache: FILE:/tmp/krb5cc_sdfa\nDefault principal: {}@{}\nValid starting       Expires              Service principal\n10/01/2019 12:44:18  10/08/2019 12:44:14   krbtgt/service@service\nrenew until 10/22/2019 15:04:20'.format(username, service)  # NOQA
+        self.assertEqual(username,
+                         _parse_principal_name_from_klist(correct_out))
+
+    def test_get_principal_name_from_klist(self):
+        assert _get_principal_name_from_klist()
+
+    def test_mkdir(self):
+        test_dir_name = "testmkdir"
+        with Hdfs() as fs:
+            fs.mkdir(test_dir_name)
+            self.assertTrue(fs.isdir(test_dir_name))
+
+            fs.remove(test_dir_name)
+
+    def test_makedirs(self):
+        test_dir_name = "testmkdir/"
+        nested_dir_name = test_dir_name + "nested_dir"
+
+        with Hdfs() as fs:
+            fs.makedirs(nested_dir_name)
+            self.assertTrue(fs.isdir(nested_dir_name))
+
+            fs.remove(test_dir_name, True)
+
+    def test_picle(self):
+        pickle_file_name = "test_pickle.pickle"
+        test_data = {'test_elem1': b'balabala',
+                     'test_elem2': 'balabala'}
+
+        with Hdfs() as fs:
+            with fs.open(pickle_file_name, 'wb') as f:
+                pickle.dump(test_data, f)
+            with fs.open(pickle_file_name, 'rb') as f:
+                loaded_obj = pickle.load(f)
+                self.assertEqual(test_data, loaded_obj)
+
+            fs.remove(pickle_file_name, True)
+
+    def test_rename(self):
+        with Hdfs() as fs:
+            with fs.open('src', 'w') as fp:
+                fp.write('foobar')
+
+            self.assertTrue(fs.exists('src'))
+            self.assertFalse(fs.exists('dst'))
+
+            fs.rename('src', 'dst')
+            self.assertFalse(fs.exists('src'))
+            self.assertTrue(fs.exists('dst'))
+
+            with fs.open('dst', 'r') as fp:
+                data = fp.read()
+                assert data == 'foobar'
+
+            fs.remove('dst', True)
+
+    def test_remove(self):
+        test_file = "test_remove.txt"
+        test_dir = "test_dir/"
+        nested_dir = os.path.join(test_dir, "nested_file/")
+        nested_file = os.path.join(nested_dir, test_file)
+
+        with Hdfs() as fs:
+            with fs.open(test_file, 'w') as fp:
+                fp.write('foobar')
+
+            # test remove on one file
+            self.assertTrue(fs.exists(test_file))
+            fs.remove(test_file)
+            self.assertFalse(fs.exists(test_file))
+
+            # test remove on directory
+            fs.makedirs(nested_dir)
+            with fs.open(nested_file, 'w') as fp:
+                fp.write('foobar')
+
+            self.assertTrue(fs.exists(test_dir))
+            self.assertTrue(fs.exists(nested_dir))
+            self.assertTrue(fs.exists(nested_file))
+
+            fs.remove(test_dir, True)
+
+            self.assertFalse(fs.exists(test_dir))
+            self.assertFalse(fs.exists(nested_dir))
+            self.assertFalse(fs.exists(nested_file))
+
+    def test_stat_file(self):
+        test_file_name = "testfile"
+
+        with Hdfs() as fs:
+            with fs.open(test_file_name, 'w') as fp:
+                fp.write('foobar')
+
+            conn = hdfs.connect()
+            expected = conn.info(test_file_name)
+
+            stat = fs.stat(test_file_name)
+            self.assertIsInstance(stat, HdfsFileStat)
+            self.assertTrue(stat.filename.endswith(test_file_name))
+            self.assertFalse(stat.isdir())
+            self.assertEqual(stat.mode & 0o777, expected['permissions'])
+            self.assertTrue(stat.mode & 0o100000)
+            self.assertIsInstance(stat.last_accessed, float)
+            self.assertIsInstance(stat.last_modified, float)
+            for k in ('size', 'owner', 'group', 'replication',
+                      'block_size', 'kind', 'last_accessed', 'last_modified'):
+                self.assertEqual(getattr(stat, k), expected[k])
+
+            fs.remove(test_file_name)
+
+    def test_stat_directory(self):
+        test_dir_name = "testmkdir"
+        with Hdfs() as fs:
+            fs.mkdir(test_dir_name)
+
+            conn = hdfs.connect()
+            expected = conn.info(test_dir_name)
+
+            stat = fs.stat(test_dir_name)
+            self.assertIsInstance(stat, HdfsFileStat)
+            self.assertTrue(stat.filename.endswith(test_dir_name))
+            self.assertTrue(stat.isdir())
+            self.assertEqual(stat.mode & 0o777, expected['permissions'])
+            self.assertTrue(stat.mode & 0o40000)
+            self.assertIsInstance(stat.last_accessed, float)
+            self.assertIsInstance(stat.last_modified, float)
+            for k in ('size', 'owner', 'group', 'replication',
+                      'block_size', 'kind', 'last_accessed', 'last_modified'):
+                self.assertEqual(getattr(stat, k), expected[k])
+
+            fs.remove(test_dir_name)
+
+
+@unittest.skipIf(shutil.which('hdfs') is None, "HDFS client not installed")
+class TestHdfsFsWithFile(unittest.TestCase):
+
+    def setUp(self):
+        self.test_string = "this is a test string\n"
+        self.tmpfile_name = "tmpfile.txt"
+
+        with Hdfs() as fs:
+            with fs.open(self.tmpfile_name, "w") as tmpfile:
+                tmpfile.write(self.test_string)
+
+    def tearDown(self):
+        with Hdfs() as fs:
+            try:
+                fs.remove(self.tmpfile_name)
+            except IOError:
+                pass
+
+    def test_read_string(self):
+        with Hdfs() as fs:
+            with fs.open(self.tmpfile_name, "r") as f:
+                self.assertEqual(self.test_string, f.read())
+            with fs.open(self.tmpfile_name, "r") as f:
+                self.assertEqual(self.test_string, f.readline())
+
+    def test_list(self):
+        with Hdfs() as fs:
+            file_generator = fs.list()
+            self.assertIsInstance(file_generator, Iterable)
+            file_list = list(file_generator)
+            self.assertIn(self.tmpfile_name, file_list, self.tmpfile_name)
+
+            # An exception is raised when the given path is not a directory
+            self.assertRaises(NotADirectoryError, list,
+                              fs.list(self.tmpfile_name))
+            for test_dir_name in ["testmkdir", "testmkdir/"]:
+                nested_dir_name1 = "nested_dir1"
+                nested_dir_name2 = "nested_dir2"
+                nested_file_name = "file"
+                nested_dir1 = os.path.join(test_dir_name, nested_dir_name1)
+                nested_dir2 = os.path.join(test_dir_name, nested_dir_name2)
+                nested_file = os.path.join(nested_dir2,  nested_file_name)
+                nested_file_relative = os.path.join(nested_dir_name2,
+                                                    nested_file_name)
+
+                try:
+                    fs.makedirs(nested_dir1)
+                    fs.makedirs(nested_dir2)
+
+                    with fs.open(nested_file, "w") as f:
+                        f.write(self.test_string)
+
+                    recursive_file_generator = fs.list(test_dir_name,
+                                                       recursive=True)
+                    self.assertIsInstance(recursive_file_generator, Iterable)
+                    file_list = list(recursive_file_generator)
+                    self.assertIn(nested_dir_name1, file_list)
+                    self.assertIn(nested_dir_name2, file_list)
+                    self.assertIn(nested_file_relative, file_list)
+
+                    normal_file_generator = fs.list(test_dir_name)
+                    self.assertIsInstance(recursive_file_generator, Iterable)
+                    file_list = list(normal_file_generator)
+                    self.assertIn(nested_dir_name1, file_list)
+                    self.assertIn(nested_dir_name2, file_list)
+                    self.assertNotIn(nested_file_relative, file_list)
+                finally:
+                    fs.remove(test_dir_name, True)
+
+    def test_isdir(self):
+        with Hdfs() as fs:
+            self.assertTrue(fs.isdir("/"))
+            self.assertFalse(fs.isdir(self.tmpfile_name))
+
+    def test_exists(self):
+        non_exist_file = "non_exist_file.txt"
+
+        with Hdfs() as fs:
+            self.assertTrue(fs.exists(self.tmpfile_name))
+            self.assertTrue(fs.exists("/"))
+            self.assertFalse(fs.exists(non_exist_file))
+
+
+@unittest.skipIf(shutil.which('hdfs') is None, "HDFS client not installed")
+class TestHdfsWithBinaryFile(unittest.TestCase):
+
+    def setUp(self):
+        test_string = "this is a test string\n"
+        self.test_string_b = test_string.encode("utf-8")
+        self.fs = "hdfs"
+        self.tmpfile_name = "tmpfile.txt"
+
+        with Hdfs() as fs:
+            with fs.open(self.tmpfile_name, "wb") as tmpfile:
+                tmpfile.write(self.test_string_b)
+
+    def tearDown(self):
+        with Hdfs() as fs:
+            try:
+                fs.remove(self.tmpfile_name)
+            except IOError:
+                pass
+
+    def test_read_bytes(self):
+        with Hdfs() as fs:
+            with fs.open(self.tmpfile_name, "rb") as f:
+                self.assertEqual(self.test_string_b, f.read())

--- a/tests/v2_tests/test_local.py
+++ b/tests/v2_tests/test_local.py
@@ -1,0 +1,245 @@
+import os
+import pickle
+import tempfile
+import unittest
+from collections.abc import Iterable
+
+from pfio.v2 import Local, LocalFileStat
+
+
+class TestLocal(unittest.TestCase):
+
+    def setUp(self):
+        self.test_string_str = "this is a test string\n"
+        self.test_string_bytes = self.test_string_str.encode("utf-8")
+
+    def test_read_string(self):
+
+        with Local() as fs:
+            with tempfile.NamedTemporaryFile("w+t", delete=False) as tmpfile:
+                tmpfile_path = tmpfile.name
+                tmpfile.write(self.test_string_str)
+
+            with fs.open(tmpfile_path, mode="r") as loaded_file:
+                self.assertEqual(self.test_string_str, loaded_file.read())
+
+            with fs.open(tmpfile_path, mode="r") as loaded_file:
+                self.assertEqual(self.test_string_str, loaded_file.readline())
+
+            fs.remove(tmpfile_path)
+
+    def test_read_bytes(self):
+
+        with Local() as fs:
+            with tempfile.NamedTemporaryFile("w+b", delete=False) as tmpfile:
+                tmpfile_path = tmpfile.name
+                tmpfile.write(self.test_string_bytes)
+
+            with fs.open(tmpfile_path, mode="rb") as loaded_file:
+                self.assertEqual(self.test_string_bytes, loaded_file.read())
+
+            fs.remove(tmpfile_path)
+
+    def test_open_non_exist(self):
+
+        non_exist_file = "non_exist_file.txt"
+        if os.path.exists(non_exist_file):
+            os.remove(non_exist_file)
+
+        with Local() as fs:
+            self.assertRaises(IOError, fs.open, non_exist_file)
+
+    def test_list(self):
+        # directory layout
+        # testlsdir
+        # | - nested_dir1
+        # |   | - nested_dir3
+        # | _ nested_dir2
+        for test_dir_name in ["testlsdir", "testlsdir/"]:
+            try:
+                tmpdir = tempfile.TemporaryDirectory()
+                nested_dir_name1 = "nested_dir1"
+                nested_dir_name2 = "nested_dir2"
+                nested_dir_name3 = "nested_dir3"
+                test_dir_path = os.path.join(tmpdir.name, test_dir_name)
+                nested_dir_path1 = os.path.join(test_dir_path,
+                                                nested_dir_name1)
+                nested_dir_path2 = os.path.join(test_dir_path,
+                                                nested_dir_name2)
+                nested_dir_path3 = os.path.join(nested_dir_path1,
+                                                nested_dir_name3)
+                nested_dir_relative_path3 = os.path.join(nested_dir_name1,
+                                                         nested_dir_name3)
+
+                with Local() as fs:
+                    fs.makedirs(nested_dir_path1)
+                    fs.makedirs(nested_dir_path2)
+                    fs.makedirs(nested_dir_path3)
+
+                    self.assertIsInstance(fs.list(), Iterable)
+                    full_list = list(fs.list(test_dir_path, recursive=True))
+                    self.assertIn(nested_dir_name1, full_list)
+                    self.assertIn(nested_dir_name2, full_list)
+                    self.assertIn(nested_dir_relative_path3, full_list)
+
+                    first_level_list_of_file = list(fs.list(
+                        test_dir_path))
+                    self.assertIn(nested_dir_name1, first_level_list_of_file)
+                    self.assertIn(nested_dir_name2, first_level_list_of_file)
+                    self.assertNotIn(nested_dir_relative_path3,
+                                     first_level_list_of_file)
+            finally:
+                tmpdir.cleanup()
+
+    def test_isdir(self):
+        with Local() as fs:
+            self.assertTrue(fs.isdir("/"))
+            self.assertFalse(fs.isdir("test_posix_handler.py"))
+
+    def test_mkdir(self):
+        test_dir_name = "testmkdir"
+        with Local() as fs:
+            fs.mkdir(test_dir_name)
+            self.assertTrue(fs.isdir(test_dir_name))
+
+            fs.remove(test_dir_name)
+
+    def test_makedirs(self):
+        test_dir_name = "testmkdir/"
+        nested_dir_name = test_dir_name + "nested_dir"
+
+        with Local() as fs:
+            fs.makedirs(nested_dir_name)
+            self.assertTrue(fs.isdir(nested_dir_name))
+
+            fs.remove(test_dir_name, True)
+
+    def test_picle(self):
+
+        pickle_file_name = "test_pickle.pickle"
+        test_data = {'test_elem1': b'balabala',
+                     'test_elem2': 'balabala'}
+
+        with Local() as fs:
+            with fs.open(pickle_file_name, 'wb') as f:
+                pickle.dump(test_data, f)
+            with fs.open(pickle_file_name, 'rb') as f:
+                loaded_obj = pickle.load(f)
+                self.assertEqual(test_data, loaded_obj)
+
+            fs.remove(pickle_file_name)
+
+    def test_exists(self):
+        non_exist_file = "non_exist_file.txt"
+
+        with Local() as fs:
+            self.assertTrue(fs.exists(__file__))
+            self.assertTrue(fs.exists("/"))
+            self.assertFalse(fs.exists(non_exist_file))
+
+    def test_rename(self):
+        with Local() as fs:
+            with fs.open('src', 'w') as fp:
+                fp.write('foobar')
+
+            self.assertTrue(fs.exists('src'))
+            self.assertFalse(fs.exists('dst'))
+
+            fs.rename('src', 'dst')
+            self.assertFalse(fs.exists('src'))
+            self.assertTrue(fs.exists('dst'))
+
+            with fs.open('dst', 'r') as fp:
+                data = fp.read()
+                assert data == 'foobar'
+
+            fs.remove('dst')
+
+    def test_remove(self):
+        test_file = "test_remove.txt"
+        test_dir = "test_dir/"
+        nested_dir = os.path.join(test_dir, "nested_file/")
+        nested_file = os.path.join(nested_dir, test_file)
+
+        with Local() as fs:
+            with fs.open(test_file, 'w') as fp:
+                fp.write('foobar')
+
+            # test remove on one file
+            self.assertTrue(fs.exists(test_file))
+            fs.remove(test_file)
+            self.assertFalse(fs.exists(test_file))
+
+            # test remove on directory
+            fs.makedirs(nested_dir)
+            with fs.open(nested_file, 'w') as fp:
+                fp.write('foobar')
+
+            self.assertTrue(fs.exists(test_dir))
+            self.assertTrue(fs.exists(nested_dir))
+            self.assertTrue(fs.exists(nested_file))
+
+            fs.remove(test_dir, True)
+
+            self.assertFalse(fs.exists(test_dir))
+            self.assertFalse(fs.exists(nested_dir))
+            self.assertFalse(fs.exists(nested_file))
+
+    def test_stat_file(self):
+        test_file_name = "testfile"
+        with Local() as fs:
+            with fs.open(test_file_name, 'w') as fp:
+                fp.write('foobar')
+
+            expected = os.stat(test_file_name)
+
+            stat = fs.stat(test_file_name)
+            self.assertIsInstance(stat, LocalFileStat)
+            self.assertTrue(stat.filename.endswith(test_file_name))
+            self.assertFalse(stat.isdir())
+            self.assertIsInstance(stat.last_accessed, float)
+            self.assertIsInstance(stat.last_modified, float)
+            self.assertIsInstance(stat.created, float)
+            keys = (('last_modified', 'st_mtime'),
+                    ('last_accessed', 'st_atime'),
+                    ('last_modified_ns', 'st_mtime_ns'),
+                    ('last_accessed_ns', 'st_atime_ns'),
+                    ('created', 'st_ctime'), ('created_ns', 'st_ctime_ns'),
+                    ('mode', 'st_mode'), ('size', 'st_size'),
+                    ('uid', 'st_uid'), ('gid', 'st_gid'), ('ino', 'st_ino'),
+                    ('dev', 'st_dev'), ('nlink', 'st_nlink'))
+            for k, kexpect in keys:
+                self.assertEqual(getattr(stat, k), getattr(expected, kexpect))
+
+            fs.remove(test_file_name)
+
+    def test_stat_directory(self):
+        test_dir_name = "testmkdir"
+        with Local() as fs:
+            fs.mkdir(test_dir_name)
+
+            expected = os.stat(test_dir_name)
+
+            stat = fs.stat(test_dir_name)
+            self.assertIsInstance(stat, LocalFileStat)
+            self.assertTrue(stat.filename.endswith(test_dir_name))
+            self.assertTrue(stat.isdir())
+            self.assertIsInstance(stat.last_accessed, float)
+            self.assertIsInstance(stat.last_modified, float)
+            self.assertIsInstance(stat.created, float)
+            keys = (('last_modified', 'st_mtime'),
+                    ('last_accessed', 'st_atime'),
+                    ('last_modified_ns', 'st_mtime_ns'),
+                    ('last_accessed_ns', 'st_atime_ns'),
+                    ('created', 'st_ctime'), ('created_ns', 'st_ctime_ns'),
+                    ('mode', 'st_mode'), ('size', 'st_size'),
+                    ('uid', 'st_uid'), ('gid', 'st_gid'), ('ino', 'st_ino'),
+                    ('dev', 'st_dev'), ('nlink', 'st_nlink'))
+            for k, kexpect in keys:
+                self.assertEqual(getattr(stat, k), getattr(expected, kexpect))
+
+            fs.remove(test_dir_name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/v2_tests/test_local.py
+++ b/tests/v2_tests/test_local.py
@@ -78,15 +78,17 @@ class TestLocal(unittest.TestCase):
 
                     self.assertIsInstance(fs.list(), Iterable)
                     full_list = list(fs.list(test_dir_path, recursive=True))
-                    self.assertIn(nested_dir_name1, full_list)
-                    self.assertIn(nested_dir_name2, full_list)
-                    self.assertIn(nested_dir_relative_path3, full_list)
+                    self.assertIn(nested_dir_name1+'/', full_list)
+                    self.assertIn(nested_dir_name2+'/', full_list)
+                    self.assertIn(nested_dir_relative_path3+'/', full_list)
 
                     first_level_list_of_file = list(fs.list(
                         test_dir_path))
-                    self.assertIn(nested_dir_name1, first_level_list_of_file)
-                    self.assertIn(nested_dir_name2, first_level_list_of_file)
-                    self.assertNotIn(nested_dir_relative_path3,
+                    self.assertIn(nested_dir_name1+'/',
+                                  first_level_list_of_file)
+                    self.assertIn(nested_dir_name2+'/',
+                                  first_level_list_of_file)
+                    self.assertNotIn(nested_dir_relative_path3+'/',
                                      first_level_list_of_file)
             finally:
                 tmpdir.cleanup()

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -432,10 +432,13 @@ class TestZip(unittest.TestCase):
             with z.open_zip(
                     self.nested_zip_path) as nested_zip:
                 with nested_zip.open(self.nested_zipped_file_path) as f:
-                    self.assertEqual(f.read(), self.nested_test_string_b)
+                    self.assertEqual(f.read(), self.nested_test_string)
 
                 with nested_zip.open(self.nested_zipped_file_path, "r") as f:
                     self.assertEqual(f.read(), self.nested_test_string)
+
+                with nested_zip.open(self.nested_zipped_file_path, "rb") as f:
+                    self.assertEqual(f.read(), self.nested_test_string_b)
 
     @parameterized.expand([
         # path ends with slash
@@ -669,7 +672,6 @@ class TestZipListNoDirectory(unittest.TestCase):
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
-
         assert stderr == b""
 
     def tearDown(self):

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -2,9 +2,7 @@ import io
 import multiprocessing
 import os
 import pickle
-import random
 import shutil
-import string
 import subprocess
 import sys
 import tempfile
@@ -15,27 +13,8 @@ from zipfile import ZipFile
 import pytest
 from parameterized import parameterized
 
+from pfio.testing import make_random_str, make_zip
 from pfio.v2 import ZipFileStat, local
-
-
-def make_zip(zipfilename, root_dir, base_dir):
-    pwd = os.getcwd()
-    with ZipFile(zipfilename, "w") as f:
-        os.chdir(root_dir)
-        for root, dirs, filenames in os.walk(base_dir):
-            for _dir in dirs:
-                path = os.path.normpath(os.path.join(root, _dir))
-                f.write(path)
-            for _file in filenames:
-                path = os.path.normpath(os.path.join(root, _file))
-                f.write(path)
-        os.chdir(pwd)
-
-
-def make_random_str(n):
-    return ''.join([random.choice(string.ascii_letters + string.digits)
-                    for i in range(n)])
-
 
 ZIP_TEST_FILENAME_LIST = {
     "dir_name1": "testdir1",

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -1,0 +1,868 @@
+import io
+import multiprocessing
+import os
+import pickle
+import random
+import shutil
+import string
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from zipfile import ZipFile
+
+import pytest
+from parameterized import parameterized
+
+from pfio.v2 import ZipFileStat, local
+
+
+def make_zip(zipfilename, root_dir, base_dir):
+    pwd = os.getcwd()
+    with ZipFile(zipfilename, "w") as f:
+        os.chdir(root_dir)
+        for root, dirs, filenames in os.walk(base_dir):
+            for _dir in dirs:
+                path = os.path.normpath(os.path.join(root, _dir))
+                f.write(path)
+            for _file in filenames:
+                path = os.path.normpath(os.path.join(root, _file))
+                f.write(path)
+        os.chdir(pwd)
+
+
+def make_random_str(n):
+    return ''.join([random.choice(string.ascii_letters + string.digits)
+                    for i in range(n)])
+
+
+ZIP_TEST_FILENAME_LIST = {
+    "dir_name1": "testdir1",
+    "dir_name2": "testdir2",
+    "zipped_file_name": "testfile1",
+    "testfile_name": "testfile2",
+    "nested_dir_name": "nested_dir",
+    "nested_zip_file_name": "nested.zip",
+}
+
+NON_EXIST_LIST = ["does_not_exist", "does_not_exist/", "does/not/exist"]
+
+
+class TestZip(unittest.TestCase):
+
+    def setUp(self):
+        # The following zip layout is created for all the tests
+        # outside.zip
+        # | - testdir1
+        # |   | - nested1.zip
+        # |       | - nested_dir
+        # |           | - nested
+        # | - testdir2
+        # |   | - testfile1
+        # | - testfile2
+        self.test_string = "this is a test string\n"
+        self.nested_test_string = \
+            "this is a test string for nested zip\n"
+        self.test_string_b = self.test_string.encode("utf-8")
+        self.nested_test_string_b = \
+            self.nested_test_string.encode("utf-8")
+
+        # the most outside zip
+        self.zip_file_name = "outside"
+
+        # nested zip and nested file
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.nested_zipped_file_name = "nested"
+        self.nested_dir_name = ZIP_TEST_FILENAME_LIST["nested_dir_name"]
+        self.nested_dir_path = os.path.join(self.tmpdir.name,
+                                            self.nested_dir_name)
+        self.nested_zip_file_name = \
+            ZIP_TEST_FILENAME_LIST["nested_zip_file_name"]
+
+        # directory and file
+        self.dir_name1 = ZIP_TEST_FILENAME_LIST["dir_name1"]
+        self.dir_name2 = ZIP_TEST_FILENAME_LIST["dir_name2"]
+        self.zipped_file_name = ZIP_TEST_FILENAME_LIST["zipped_file_name"]
+        self.testfile_name = ZIP_TEST_FILENAME_LIST["testfile_name"]
+
+        # paths used in making outside.zip
+        dir_path1 = os.path.join(self.tmpdir.name, self.dir_name1)
+        dir_path2 = os.path.join(self.tmpdir.name, self.dir_name2)
+        testfile_path = os.path.join(self.tmpdir.name, self.testfile_name)
+        nested_dir_path = os.path.join(self.tmpdir.name, self.nested_dir_name)
+        zipped_file_path = os.path.join(dir_path2, self.zipped_file_name)
+        nested_zipped_file_path = os.path.join(
+            nested_dir_path, self.nested_zipped_file_name)
+        nested_zip_file_path = os.path.join(
+            dir_path1, self.nested_zip_file_name)
+
+        # paths used in tests
+        self.zip_file_path = self.zip_file_name + ".zip"
+        self.zipped_file_path = os.path.join(self.dir_name2,
+                                             self.zipped_file_name)
+        self.nested_zip_path = os.path.join(
+            self.dir_name1, self.nested_zip_file_name)
+        self.nested_zipped_file_path = os.path.join(
+            self.nested_dir_name, self.nested_zipped_file_name)
+
+        os.mkdir(dir_path1)
+        os.mkdir(dir_path2)
+        os.mkdir(nested_dir_path)
+
+        with open(zipped_file_path, "w") as tmpfile:
+            tmpfile.write(self.test_string)
+
+        with open(nested_zipped_file_path, "w") as tmpfile:
+            tmpfile.write(self.nested_test_string)
+
+        with open(testfile_path, "w") as tmpfile:
+            tmpfile.write(self.test_string)
+
+        make_zip(nested_zip_file_path,
+                 root_dir=self.tmpdir.name,
+                 base_dir=self.nested_dir_name)
+        shutil.rmtree(nested_dir_path)
+
+        # this will include outside.zip itself into the zip
+        make_zip(self.zip_file_path,
+                 root_dir=self.tmpdir.name,
+                 base_dir=".")
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        local.remove(self.zip_file_path)
+
+    def test_read_bytes(self):
+        with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
+            with z.open(self.zipped_file_path, "rb") as zipped_file:
+                self.assertEqual(self.test_string_b, zipped_file.read())
+
+    def test_read_string(self):
+        with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
+            with z.open(self.zipped_file_path, "r") as zipped_file:
+                self.assertEqual(self.test_string, zipped_file.readline())
+
+    def test_write_bytes(self):
+        testfile_name = "testfile3"
+        test_string = "this is a written string\n"
+        test_string_b = test_string.encode("utf-8")
+
+        with local.open_zip(os.path.abspath(self.zip_file_path), 'w') as z:
+            with z.open(testfile_name, "wb") as zipped_file:
+                zipped_file.write(test_string_b)
+
+        with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
+            with z.open(testfile_name, "rb") as zipped_file:
+                self.assertEqual(test_string_b, zipped_file.readline())
+
+    def test_write_string(self):
+        testfile_name = "testfile3"
+        test_string = "this is a written string\n"
+        with local.open_zip(os.path.abspath(self.zip_file_path), 'w') as z:
+            with z.open(testfile_name, "w") as zipped_file:
+                zipped_file.write(test_string)
+
+        with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
+            with z.open(testfile_name, "r") as zipped_file:
+                self.assertEqual(test_string, zipped_file.readline())
+
+    def test_open_non_exist(self):
+
+        non_exist_file = "non_exist_file.txt"
+
+        with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
+            # ZipFile raises KeyError while io module raises IOError
+            self.assertRaises(KeyError, z.open, non_exist_file)
+
+    @parameterized.expand([
+        # not normalized path
+        ['././{}//../{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                                   ZIP_TEST_FILENAME_LIST["dir_name2"],
+                                   ZIP_TEST_FILENAME_LIST["zipped_file_name"])]
+    ])
+    def test_open_non_normalized_path(self, path_or_prefix):
+        with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
+            with z.open(path_or_prefix, "r") as zipped_file:
+                self.assertEqual(self.test_string, zipped_file.read())
+
+    @parameterized.expand([
+        # default case get the first level from the root
+        ["",
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         False],
+        # Problem 1 in issue #66
+        [ZIP_TEST_FILENAME_LIST["dir_name2"],
+         [ZIP_TEST_FILENAME_LIST["zipped_file_name"]],
+         False],
+        # problem 2 in issue #66
+        [ZIP_TEST_FILENAME_LIST["dir_name2"],
+         [ZIP_TEST_FILENAME_LIST["zipped_file_name"]],
+         False],
+        # not normalized path
+        ['{}//{}//../'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                              ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         [ZIP_TEST_FILENAME_LIST["zipped_file_name"]],
+         False],
+        # not normalized path root
+        ['{}//..//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         False],
+        # not normalized path beyond root
+        ['//..//',
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         False],
+        # not normalized path beyond root
+        ['{}//..//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         False],
+        # starting with slash
+        ['/',
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         False],
+        # recursive test
+        ['',
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                       ZIP_TEST_FILENAME_LIST["nested_zip_file_name"]),
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                       ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         True],
+        [ZIP_TEST_FILENAME_LIST["dir_name2"],
+         [ZIP_TEST_FILENAME_LIST["zipped_file_name"]],
+         True],
+        # problem 2 in issue #66
+        [ZIP_TEST_FILENAME_LIST["dir_name2"],
+         [ZIP_TEST_FILENAME_LIST["zipped_file_name"]],
+         True],
+        # not normalized path
+        ['{}//{}//../'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                              ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         [ZIP_TEST_FILENAME_LIST["zipped_file_name"]],
+         True],
+        # not normalized path root
+        ['{}//..//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                       ZIP_TEST_FILENAME_LIST["nested_zip_file_name"]),
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                       ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         True],
+        # not normalized path beyond root
+        ['//..//',
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                       ZIP_TEST_FILENAME_LIST["nested_zip_file_name"]),
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                       ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         True],
+        # starting with slash
+        ['/',
+         [ZIP_TEST_FILENAME_LIST["dir_name1"],
+          ZIP_TEST_FILENAME_LIST["dir_name2"],
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                       ZIP_TEST_FILENAME_LIST["nested_zip_file_name"]),
+          os.path.join(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                       ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+          ZIP_TEST_FILENAME_LIST["testfile_name"]],
+         True]]
+    )
+    def test_list(self, path_or_prefix, expected_list, recursive):
+        with local.open_zip(self.zip_file_path) as z:
+            zip_generator = z.list(path_or_prefix, recursive=recursive)
+            zip_list = list(zip_generator)
+            self.assertEqual(sorted(expected_list),
+                             sorted(zip_list))
+
+    @parameterized.expand([
+        # non_exist_file
+        ['does_not_exist', FileNotFoundError],
+        # not exist but share the prefix
+        ['{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"][:1]),
+            FileNotFoundError],
+        # broken path
+        ['{}//{}/'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                          ZIP_TEST_FILENAME_LIST["zipped_file_name"][:1]),
+         FileNotFoundError],
+        # list a file
+        ['{}//{}///'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                            ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         NotADirectoryError]
+    ])
+    def test_list_with_errors(self, path_or_prefix, error):
+        with local.open_zip(self.zip_file_path) as z:
+            with self.assertRaises(error):
+                list(z.list(path_or_prefix))
+
+            with self.assertRaises(error):
+                list(z.list(path_or_prefix, recursive=True))
+
+    @parameterized.expand([
+        # path ends with slash
+        ['{}//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         True],
+        # not normalized path
+        ['{}//{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                         ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         False],
+        ['{}//..//{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                                ZIP_TEST_FILENAME_LIST["dir_name2"],
+                                ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         False],
+        # problem 2 in issue #66
+        [ZIP_TEST_FILENAME_LIST["dir_name2"],
+         True],
+        # not normalized path
+        ['{}//{}//../'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                              ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         True],
+        # not normalized path root
+        ['{}//..//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         False],
+        # not normalized path beyond root
+        ['//..//',
+         False],
+        # starting with slash
+        ['/',
+         False]]
+    )
+    def test_isdir(self, path_or_prefix, expected):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertEqual(z.isdir(path_or_prefix),
+                             expected)
+
+    @parameterized.expand(NON_EXIST_LIST)
+    def test_isdir_non_exist(self, path_or_prefix):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertFalse(z.isdir(path_or_prefix))
+
+    def test_mkdir(self):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertRaises(io.UnsupportedOperation, z.mkdir, "test")
+
+    def test_makedirs(self):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertRaises(io.UnsupportedOperation,
+                              z.makedirs, "test/test")
+
+    def test_pickle(self):
+        pickle_file_name = "test_pickle.pickle"
+        test_data = {'test_elem1': b'balabala',
+                     'test_elem2': 'balabala'}
+        pickle_zip = "test_pickle.zip"
+
+        with open(pickle_file_name, "wb") as f:
+            pickle.dump(test_data, f)
+
+        with ZipFile(pickle_zip, "w") as test_zip:
+            test_zip.write(pickle_file_name)
+
+        with local.open_zip(pickle_zip) as z:
+            with z.open(pickle_file_name, 'rb') as f:
+                loaded_obj = pickle.load(f)
+                self.assertEqual(test_data, loaded_obj)
+
+        os.remove(pickle_file_name)
+        os.remove(pickle_zip)
+
+    @parameterized.expand([
+        # path ends with slash
+        ['{}//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         True],
+        # not normalized path
+        ['{}//{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                         ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         True],
+        ['{}//..//{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                                ZIP_TEST_FILENAME_LIST["dir_name2"],
+                                ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         True],
+        ['{}//..//{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                                ZIP_TEST_FILENAME_LIST["dir_name2"],
+                                ZIP_TEST_FILENAME_LIST["zipped_file_name"][:-1]
+                                ),
+         False],
+        # # not normalized path
+        ['{}//{}//../'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                              ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         True],
+        # not normalized path root
+        ['{}//..//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         False],
+        # not normalized path beyond root
+        ['//..//',
+         False],
+        # starting with slash
+        ['/',
+         False]]
+    )
+    def test_exists(self, path_or_prefix, expected):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertEqual(z.exists(path_or_prefix),
+                             expected)
+
+    @parameterized.expand(NON_EXIST_LIST)
+    def test_not_exists(self, non_exist_file):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertFalse(z.exists(non_exist_file))
+
+    def test_remove(self):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertRaises(io.UnsupportedOperation,
+                              z.remove, "test/test", False)
+
+    def test_nested_zip(self):
+        with local.open_zip(self.zip_file_path) as z:
+            with z.open_zip(
+                    self.nested_zip_path) as nested_zip:
+                with nested_zip.open(self.nested_zipped_file_path) as f:
+                    self.assertEqual(f.read(), self.nested_test_string_b)
+
+                with nested_zip.open(self.nested_zipped_file_path, "r") as f:
+                    self.assertEqual(f.read(), self.nested_test_string)
+
+    @parameterized.expand([
+        # path ends with slash
+        ['{}//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+         '{}/'.format(ZIP_TEST_FILENAME_LIST["dir_name2"])],
+        # not normalized path
+        ['{}//{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                         ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         '{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                        ZIP_TEST_FILENAME_LIST["zipped_file_name"])],
+        ['{}//..//{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name1"],
+                                ZIP_TEST_FILENAME_LIST["dir_name2"],
+                                ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+         '{}/{}'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                        ZIP_TEST_FILENAME_LIST["zipped_file_name"])],
+        ['{}//{}//../'.format(ZIP_TEST_FILENAME_LIST["dir_name2"],
+                              ZIP_TEST_FILENAME_LIST["zipped_file_name"]),
+            '{}/'.format(ZIP_TEST_FILENAME_LIST["dir_name2"])]
+    ])
+    def test_stat(self, path_or_prefix, expected):
+        with local.open_zip(self.zip_file_path) as z:
+            self.assertEqual(expected, z.stat(path_or_prefix).filename)
+
+    @parameterized.expand([
+        # not normalized path root
+        '{}//..//'.format(ZIP_TEST_FILENAME_LIST["dir_name2"]),
+        # not normalized path beyond root
+        '//..//',
+        # root
+        '/'] + NON_EXIST_LIST)
+    def test_stat_non_exist(self, path_or_prefix):
+        with local.open_zip(self.zip_file_path) as z:
+            with self.assertRaises(FileNotFoundError):
+                z.stat(path_or_prefix)
+
+    def test_stat_file(self):
+        test_file_name = 'testdir2/testfile1'
+        expected = ZipFile(self.zip_file_path).getinfo(test_file_name)
+
+        with local.open_zip(self.zip_file_path) as z:
+            stat = z.stat(test_file_name)
+            self.assertIsInstance(stat, ZipFileStat)
+            self.assertTrue(stat.filename.endswith(test_file_name))
+            self.assertEqual(stat.size, expected.file_size)
+            self.assertEqual(stat.mode, expected.external_attr >> 16)
+            self.assertFalse(stat.isdir())
+
+            expected_mtime = datetime(*expected.date_time).timestamp()
+            self.assertIsInstance(stat.last_modified, float)
+            self.assertEqual(stat.last_modified, expected_mtime)
+
+            for k in ('filename', 'orig_filename', 'comment', 'create_system',
+                      'create_version', 'extract_version', 'flag_bits',
+                      'volume', 'internal_attr', 'external_attr', 'CRC',
+                      'header_offset', 'compress_size', 'compress_type'):
+                self.assertEqual(getattr(stat, k), getattr(expected, k))
+
+    def test_stat_directory(self):
+        test_dir_name = 'testdir2/'
+        expected = ZipFile(self.zip_file_path).getinfo(test_dir_name)
+
+        with local.open_zip(self.zip_file_path) as z:
+            stat = z.stat(test_dir_name)
+            self.assertIsInstance(stat, ZipFileStat)
+            self.assertTrue(stat.filename.endswith(test_dir_name))
+            self.assertEqual(stat.size, expected.file_size)
+            self.assertEqual(stat.mode, expected.external_attr >> 16)
+            self.assertTrue(stat.isdir())
+
+            expected_mtime = datetime(*expected.date_time).timestamp()
+            self.assertIsInstance(stat.last_modified, float)
+            self.assertEqual(stat.last_modified, expected_mtime)
+
+            for k in ('filename', 'orig_filename', 'comment', 'create_system',
+                      'create_version', 'extract_version', 'flag_bits',
+                      'volume', 'internal_attr', 'external_attr', 'CRC',
+                      'header_offset', 'compress_size', 'compress_type'):
+                self.assertEqual(getattr(stat, k), getattr(expected, k))
+
+    def test_writing_after_listing(self):
+        testfile_name = "testfile3"
+        test_string = "this is a written string\n"
+
+        with local.open_zip(
+                os.path.abspath(self.zip_file_path), 'w') as z:
+            list(z.list())
+
+            with z.open(testfile_name, "w") as zipped_file:
+                zipped_file.write(test_string)
+
+    @pytest.mark.skipif(sys.version_info > (3, 5),
+                        reason="requires python3.5 or lower")
+    def test_mode_w_exception(self):
+        testfile_name = "testfile3"
+        test_string = "this is a written string\n"
+
+        with local.open_zip(
+                os.path.abspath(self.zip_file_path)) as z:
+            with self.assertRaises(ValueError):
+                with z.open(testfile_name, "w") as zipped_file:
+                    zipped_file.write(test_string)
+
+
+class TestZipWithLargeData(unittest.TestCase):
+    def setUp(self):
+        # The following zip layout is created for all the tests
+        # outside.zip
+        # | - testfile1
+
+        n = 1 << 20
+        self.test_string = make_random_str(n)
+
+        # the most outside zip
+        self.zip_file_name = "outside"
+
+        # nested zip and nested file
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+        # test file
+        self.testfile_name = "testfile1"
+
+        # paths used in making outside.zip
+        testfile_path = os.path.join(self.tmpdir.name, self.testfile_name)
+
+        # paths used in tests
+        self.zip_file_path = self.zip_file_name + ".zip"
+
+        with open(testfile_path, "w") as tmpfile:
+            tmpfile.write(self.test_string)
+
+        # this will include outside.zip itself into the zip
+        make_zip(self.zip_file_path,
+                 root_dir=self.tmpdir.name,
+                 base_dir=".")
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        local.remove(self.zip_file_path)
+
+    def test_read_multi_processes(self):
+        barrier = multiprocessing.Barrier(2)
+        with local.open_zip(
+                os.path.abspath(self.zip_file_path)) as z:
+            with z.open(self.testfile_name) as f:
+                f.read()
+
+            def func():
+                # accessing the shared container isn't supported in v2
+                with self.assertRaises(RuntimeError):
+                    with z.open(self.testfile_name) as f:
+                        barrier.wait()
+                        f.read()
+
+            p1 = multiprocessing.Process(target=func)
+            p2 = multiprocessing.Process(target=func)
+            p1.start()
+            p2.start()
+
+            p1.join(timeout=1)
+            p2.join(timeout=1)
+
+            self.assertEqual(p1.exitcode, 0)
+            self.assertEqual(p2.exitcode, 0)
+
+
+NO_DIRECTORY_FILENAME_LIST = {
+    "dir1_name": "testdir1",
+    "dir2_name": "testdir2",
+    "dir3_name": "testdir3",
+    "testfile1_name": "testfile1",
+    "testfile2_name": "testfile2",
+    "testfile3_name": "testfile3",
+    "testfile4_name": "testfile4",
+}
+
+
+class TestZipListNoDirectory(unittest.TestCase):
+    def setUp(self):
+        # The following zip layout is created for all the tests
+        # The difference is despite showing in the following layout for
+        # readabilty, the directories are not included in the zip
+        # outside.zip
+        # | - testdir1
+        # | - | - testfile1
+        # | - | - testdir2
+        # | - | - | - testfile2
+        # | - testdir3
+        # |   | - testfile3
+        # | - testfile4
+
+        self.test_string = "this is a test string\n"
+
+        # the most outside zip
+        self.zip_file_name = "outside.zip"
+
+        # nested zip and nested file
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+        # directory and file
+        self.dir1_name = NO_DIRECTORY_FILENAME_LIST["dir1_name"]
+        self.dir2_name = NO_DIRECTORY_FILENAME_LIST["dir2_name"]
+        self.dir3_name = NO_DIRECTORY_FILENAME_LIST["dir3_name"]
+        self.testfile1_name = NO_DIRECTORY_FILENAME_LIST["testfile1_name"]
+        self.testfile2_name = NO_DIRECTORY_FILENAME_LIST["testfile2_name"]
+        self.testfile3_name = NO_DIRECTORY_FILENAME_LIST["testfile3_name"]
+        self.testfile4_name = NO_DIRECTORY_FILENAME_LIST["testfile4_name"]
+
+        # paths used in making outside.zip
+        dir1_path = os.path.join(self.tmpdir.name, self.dir1_name)
+        dir2_path = os.path.join(dir1_path, self.dir2_name)
+        dir3_path = os.path.join(self.tmpdir.name, self.dir3_name)
+        testfile1_path = os.path.join(dir1_path, self.testfile1_name)
+        testfile2_path = os.path.join(dir2_path, self.testfile2_name)
+        testfile3_path = os.path.join(dir3_path, self.testfile3_name)
+        testfile4_path = os.path.join(self.tmpdir.name, self.testfile4_name)
+
+        # paths used in tests
+        for dir in [dir1_path, dir2_path, dir3_path]:
+            os.mkdir(dir)
+
+        for file_path in [testfile1_path, testfile2_path,
+                          testfile3_path, testfile4_path]:
+            with open(file_path, "w") as f:
+                f.write(self.test_string)
+
+        # create zip without directory
+        self.pwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+        cmd = ["zip", "-rD", self.zip_file_name, "."]
+
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+
+        assert stderr == b""
+
+    def tearDown(self):
+        os.chdir(self.pwd)
+        self.tmpdir.cleanup()
+
+    @parameterized.expand([
+        # default case get the first level from the root
+        ["", [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+              NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+              NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         False],
+        # Problem 1 in issue #66
+        [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+         [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
+          NO_DIRECTORY_FILENAME_LIST["dir2_name"]],
+         False],
+        # problem 2 in issue #66
+        [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                      NO_DIRECTORY_FILENAME_LIST["dir2_name"]),
+         [NO_DIRECTORY_FILENAME_LIST["testfile2_name"]],
+         False],
+        # not normalized path
+        ['{}//{}//../'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                              NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
+          NO_DIRECTORY_FILENAME_LIST["dir2_name"]],
+         False],
+        # not normalized path root
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]),
+         [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+          NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         False],
+        # not normalized path beyond root
+        ['//..//',
+         [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+          NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         False],
+        # not normalized path beyond root
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]),
+         [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+          NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         False],
+        # starting with slash
+        ['/', [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+               NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+               NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         False],
+        # recursive test
+        ['',
+         [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile3_name"]),
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         True],
+        [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+         [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
+         True],
+        # problem 2 in issue #66
+        [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+         [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
+         True],
+        # not normalized path
+        ['{}//{}//../'.format(
+            NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
+         True],
+        # not normalized path root
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir2_name"]),
+         [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile3_name"]),
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         True],
+        # not normalized path beyond root
+        ['//..//',
+         [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile3_name"]),
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         True],
+        # not normalized path beyond root
+        ['{}//..//../'.format(NO_DIRECTORY_FILENAME_LIST["dir2_name"]),
+         [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile3_name"]),
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         True],
+        # starting with slash
+        ['/',
+         [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                       NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile2_name"]),
+          os.path.join(NO_DIRECTORY_FILENAME_LIST["dir3_name"],
+                       NO_DIRECTORY_FILENAME_LIST["testfile3_name"]),
+          NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
+         True]
+    ])
+    def test_list(self, path_or_prefix, expected_list, recursive):
+        with local.open_zip(self.zip_file_name) as z:
+            zip_generator = z.list(path_or_prefix, recursive=recursive)
+            zip_list = list(zip_generator)
+            self.assertEqual(sorted(expected_list),
+                             sorted(zip_list))
+
+    @parameterized.expand([
+        # non_exist_file
+        ['does_not_exist', FileNotFoundError],
+        # not exist but share the prefix
+        ['t', FileNotFoundError],
+        # broken path
+        ['{}//t/'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]),
+            FileNotFoundError],
+        # list a file
+        ['{}//{}///'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         NotADirectoryError],
+        # list a non_exist_dir but share the surfix
+        ['{}/'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"][:-1]),
+         FileNotFoundError]
+    ])
+    def test_list_with_errors(self, path_or_prefix, error):
+        with local.open_zip(self.zip_file_name) as z:
+            with self.assertRaises(error):
+                list(z.list(path_or_prefix))
+
+            with self.assertRaises(error):
+                list(z.list(path_or_prefix, recursive=True))
+
+    @parameterized.expand([
+        # path ends with slash
+        ['{}//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), True],
+        # not normalized path
+        ['{}//{}'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                         NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         False],
+        ['{}//..//{}/{}'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                                NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                                NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         False],
+        # problem 2 in issue #66
+        [NO_DIRECTORY_FILENAME_LIST["dir1_name"], True],
+        # not normalized path
+        ['{}//{}//../'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+                              NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         True],
+        # not normalized path root
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), False],
+        # not normalized path beyond root
+        ['//..//', False],
+        # not normalized path beyond root
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), False],
+        # starting with slash
+        ['/', False]
+    ])
+    def test_isdir(self, path_or_prefix, expected):
+        with local.open_zip(self.zip_file_name) as z:
+            self.assertEqual(z.isdir(path_or_prefix),
+                             expected)
+
+    @parameterized.expand([
+        ["does_not_exist"],
+        ["does_not_exist/"],
+        ["does/not/exist"]
+    ])
+    def test_isdir_not_exist(self, dir):
+        with local.open_zip(self.zip_file_name) as z:
+            self.assertFalse(z.isdir(dir))


### PR DESCRIPTION
I've drafted a new API to solve existing issues that stem from API design. Partial AWS S3 API support is also added.

(copy from doc)

PFIO v2 API tries to solve the impedance mismatch between different
local filesystem, NFS, and other object storage systems, with a lot
simpler and cleaner code.

It has removed several toplevel functions that seem to be less
important. It turned out that they introduced more complexity than
originally intended, due to the need of the global context. Thus,
functions that depends on the global context such as ``open()``,
``set_root()`` and etc. have been removed in v2 API.

Instead, v2 API provides only two toplevel functions that enable
direct resource access with full URL: ``open_url()`` and
``fs.from_url()``. The former opens a file and returns FileObject. The
latter, creates a ``fs.FS`` object that enable resource access under
the URL. The new class ``fs.FS``, is something close to handler object
in version 1 API. ``fs.FS`` is intended to be as much compatible as
possible, however, it has several differences.

One notable difference is that it has the virtual concept of current
working directory, and thus provides ``subfs()`` method. ``subfs()``
method behaves like ``os.chdir()`` without actually changing current
working directory of the process, but actually returns a *new*
``fs.FS`` object that has different working directory. All resouce
access through the object automatically prepends the working
directory.

V2 API does not provide lazy resouce initialization any more. Instead,
it provides simple wrapper ``recreate_on_fork``, which recreates the
``fs.FS`` object every time the object experiences ``fork(2)``. ``Hdfs``
and ``Zip`` can be wrapped with it, and will be fork-tolerant object.
