### PR TITLE
Overwrite flush method of ObjectWriter in s3.py

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -62,8 +62,6 @@ class _ObjectWriter(io.BufferedWriter):
 
     def flush(self):
         '''Does nothing
-
-        .. note:: see discussion in ``S3.isdir()``.
         '''
         pass
 

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -60,6 +60,13 @@ class _ObjectWriter(io.BufferedWriter):
     def write(self, buf):
         self.buf += buf
 
+    def flush(self):
+        '''Does nothing
+
+        .. note:: see discussion in ``S3.isdir()``.
+        '''
+        pass
+
     def close(self):
         # TODO: MPU
         # See:  https://boto3.amazonaws.com/v1/documentation/


### PR DESCRIPTION
Some function (e.g., `torch.save`) invoke `flush` method explicitly. But `_ObjectWriter` in s3.py raises `ValueError: ('I/O operation on uninitialized object')` because flush is not supported in S3.

This PR overwrites `flush` method to avoid the above exception.