### PR TITLE
Fix last_modified attr in S3ObjectStat

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -12,7 +12,7 @@ from .fs import FS, FileStat
 class S3ObjectStat(FileStat):
     def __init__(self, key, head):
         self.filename = key
-        self.last_modified = head['LastModified']
+        self.last_modified = head['LastModified'].timestamp()
         self.size = head['ContentLength']
         self.metadata = head['Metadata']
         self._head = head

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -63,6 +63,7 @@ def test_smoke(target):
         assert len(content) == st.size
         assert st.filename is not None
         assert st.last_modified is not None
+        assert type(st.last_modified) == float
 
         fs.remove(filename)
 

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -31,20 +31,3 @@ def test_s3():
             assert [] == list(s3.list('base/'))
             assert ['foo.txt'] == list(s3.list('/base'))
             assert ['foo.txt'] == list(s3.list('/base/'))
-
-
-@mock_s3
-def test_s3_stat():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
-            with s3.open('foo.txt', 'w') as fp:
-                fp.write('bar')
-                assert not fp.closed
-            stat = s3.stat("foo.txt")
-
-            assert type(stat.last_modified) == float

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -31,3 +31,20 @@ def test_s3():
             assert [] == list(s3.list('base/'))
             assert ['foo.txt'] == list(s3.list('/base'))
             assert ['foo.txt'] == list(s3.list('/base/'))
+
+
+@mock_s3
+def test_s3_stat():
+    bucket = "test-dummy-bucket"
+    key = "it's me!deadbeef"
+    secret = "asedf;lkjdf;a'lksjd"
+    with S3(bucket, create_bucket=True):
+        with from_url('s3://test-dummy-bucket/base',
+                      aws_access_key_id=key,
+                      aws_secret_access_key=secret) as s3:
+            with s3.open('foo.txt', 'w') as fp:
+                fp.write('bar')
+                assert not fp.closed
+            stat = s3.stat("foo.txt")
+
+            assert type(stat.last_modified) == float


### PR DESCRIPTION
`last_modified` attribute in `S3ObjectStat` is datetime, while Local fs's `last_modified` attribute is floating point value.