### PR TITLE
No use of NFS for file cache

### DIFF
--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -8,7 +8,7 @@ import warnings
 from struct import calcsize, pack, unpack
 
 from pfio import cache
-from pfio.cache.file_cache import _DEFAULT_CACHE_PATH
+from pfio.cache.file_cache import _DEFAULT_CACHE_PATH, _check_local
 
 
 class _NoOpenNamedTemporaryFile(object):
@@ -159,6 +159,7 @@ class MultiprocessFileCache(cache.Cache):
         else:
             self.dir = dir
         os.makedirs(self.dir, exist_ok=True)
+        _check_local(self.dir)
 
         self.closed = False
         self._frozen = False

--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -1,7 +1,10 @@
 import os
 import random
 import string
+import subprocess
 from zipfile import ZipFile
+
+import mock
 
 
 class ZipForTest:
@@ -66,3 +69,21 @@ def make_random_str(n):
 def randstring():
     letters = string.ascii_letters + string.digits
     return (''.join(random.choice(letters) for _ in range(16)))
+
+
+def patch_subprocess(stdout, stderr=b''):
+    def decorator(f):
+        def wrapper(*args, **kwargs):
+            orig_method = subprocess.run
+            try:
+                cp = subprocess.CompletedProcess(args='hoge', returncode=0)
+                cp.stdout = stdout
+                cp.stderr = stderr
+                subprocess.run = mock.create_autospec(subprocess.run,
+                                                      return_value=cp)
+                return f(*args, **kwargs)
+            finally:
+                subprocess.run = orig_method
+
+        return wrapper
+    return decorator

--- a/tests/cache_tests/test_file_cache.py
+++ b/tests/cache_tests/test_file_cache.py
@@ -1,6 +1,10 @@
 import tempfile
 
+import pytest
+
+import pfio
 from pfio.cache import FileCache, MultiprocessFileCache
+from pfio.testing import patch_subprocess
 
 
 def test_preservation_interoperability():
@@ -22,3 +26,24 @@ def test_preservation_interoperability():
         assert cache2.preload('preserved') is True
         for i in range(10):
             assert str(i) == cache2.get(i)
+
+
+@patch_subprocess(b'ext3/ext4')
+def test_no_nfs():
+    FileCache(dir='var', length=214)
+
+    MultiprocessFileCache(dir='var', length=234)
+
+
+@patch_subprocess(b'nfs')
+def test_nfs():
+    with pytest.raises(ValueError):
+        FileCache(dir='var', length=214)
+
+    with pytest.raises(ValueError):
+        MultiprocessFileCache(dir='var', length=214)
+
+    pfio.cache.file_cache._FORCE_LOCAL = False
+
+    FileCache(dir='var', length=214)
+    MultiprocessFileCache(dir='var', length=214)


### PR DESCRIPTION
It requires `stat(1)` which is included in GNU coreutils. I think we can assume it.