### PR TITLE
Add _checkfork() in S3.open as a foolproof (fix #174)

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -201,6 +201,7 @@ class S3(FS):
         .. note:: Multi-part upload is not yet available.
 
         '''
+        self._checkfork()
         if 'a' in mode:
             raise io.UnsupportedOperation('Append is not supported')
         if 'r' in mode and 'w' in mode:

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -1,9 +1,10 @@
-import pytest
 import multiprocessing as mp
+
+import pytest
 from moto import mock_s3
 
-from pfio.v2.fs import ForkedError
 from pfio.v2 import S3, from_url
+from pfio.v2.fs import ForkedError
 
 
 @mock_s3

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -1,4 +1,4 @@
-import os
+import pytest
 import multiprocessing as mp
 from moto import mock_s3
 
@@ -39,8 +39,9 @@ def test_s3():
                 try:
                     s3.open('foo.txt', 'r')
                 except ForkedError:
-                    os._exit(0)
-                os._exit(1)
+                    pass
+                else:
+                    pytest.fail('No Error on Forking')
 
             p = mp.Process(target=f, args=(s3,))
             p.start()

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -1,5 +1,8 @@
+import os
+import multiprocessing as mp
 from moto import mock_s3
 
+from pfio.v2.fs import ForkedError
 from pfio.v2 import S3, from_url
 
 
@@ -31,3 +34,15 @@ def test_s3():
             assert [] == list(s3.list('base/'))
             assert ['foo.txt'] == list(s3.list('/base'))
             assert ['foo.txt'] == list(s3.list('/base/'))
+
+            def f(s3):
+                try:
+                    s3.open('foo.txt', 'r')
+                except ForkedError:
+                    os._exit(0)
+                os._exit(1)
+
+            p = mp.Process(target=f, args=(s3,))
+            p.start()
+            p.join()
+            assert p.exitcode == 0


### PR DESCRIPTION
This PR adds _checkfork() in S3.open to prevent function call under a multiprocessing situation. Fixes #174.