### PR TITLE
Use unittest.mock instead

### DIFF
--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -4,7 +4,7 @@ import string
 import subprocess
 from zipfile import ZipFile
 
-import mock
+from unittest import mock
 
 
 class ZipForTest:

--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -2,9 +2,8 @@ import os
 import random
 import string
 import subprocess
-from zipfile import ZipFile
-
 from unittest import mock
+from zipfile import ZipFile
 
 
 class ZipForTest:


### PR DESCRIPTION
The line `import mock` depends the _mock_ module from PyPI, so it also requires users to take care of an additional package installation.

It seems that this was installed at same time with some other dependencies so far; but now this line causes `ModuleNotFoundError: No module named 'mock'`.
Python provides _unittest.mock_ modules as the standard library from Python 3.3+ and this is compatible with the _mock_ module as a backport. This PR replaces `import mock` to `from unittest import mock` (revised version of #176).