### PR TITLE
Fix read(-1) call from S3 StreamBody

### DIFF
--- a/pfio/testing/__init__.py
+++ b/pfio/testing/__init__.py
@@ -65,9 +65,9 @@ def make_random_str(n):
                     for i in range(n)])
 
 
-def randstring():
+def randstring(length=16):
     letters = string.ascii_letters + string.digits
-    return (''.join(random.choice(letters) for _ in range(16)))
+    return (''.join(random.choice(letters) for _ in range(length)))
 
 
 def patch_subprocess(stdout, stderr=b''):

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -54,10 +54,10 @@ class _ObjectReader:
                                      Range=r)
         body = res['Body']
 
-        if 'b' in self._mode:
-            data = body.read(size)
+        if size < 0:
+            data = body.read()
         else:
-            data = body.read(size).decode('utf-8')
+            data = body.read(size)
 
         self.pos += len(data)
         # print('pos=', self.pos, data, size)
@@ -318,12 +318,16 @@ class S3(FS):
             obj = _ObjectReader(self.client, self.bucket, path, mode, kwargs)
             if 'b' in mode:
                 obj = io.BufferedReader(obj)
+            else:
+                obj = io.TextIOWrapper(obj)
 
         elif 'w' in mode:
             obj = _ObjectWriter(self.client, self.bucket, path, mode,
                                 self.mpu_chunksize, kwargs)
             if 'b' in mode:
                 obj = io.BufferedWriter(obj)
+            else:
+                obj = io.TextIOWrapper(obj)
 
         else:
             raise RuntimeError(f'Unknown option: {mode}')

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -33,7 +33,7 @@ def gen_fs(target):
 def test_smoke(target):
     filename = randstring()
     filename2 = randstring()
-    content = randstring()
+    content = randstring(1024)
     with gen_fs(target) as fs:
         with fs.open(filename, 'w') as fp:
             fp.write(content)
@@ -73,6 +73,11 @@ def test_smoke(target):
             buf2 = fp.read()
 
         assert content == buf2.decode()
+
+        with fs.open(filename2, 'r') as fp:
+            buf3 = fp.read()
+
+        assert content == buf3
 
         fs.remove(filename)
         fs.remove(filename2)


### PR DESCRIPTION
@HiroakiMikami reported that loading a JSON file caused an error like this:
```
  File "/home/kota/.local/lib/python3.6/site-packages/botocore/response.py", line 77, in read
    chunk = self._raw_stream.read(amt)
  File "/home/kota/.local/lib/python3.6/site-packages/urllib3/response.py", line 519, in read
    data = self._fp.read(amt) if not fp_closed else b""
  File "/usr/lib/python3.6/http/client.py", line 448, in read
    b = bytearray(amt)
ValueError: negative count
```

This is due to calling `.read(-1)` to S3 file object [directly passes `-1` to S3 StreamBody object](https://github.com/pfnet/pfio/blob/1.4.0/pfio/v2/s3.py#L60) . But S3 streambody doesn't accept negative integer, passing it directly to HTTP stream.

This change is a hotfix for 1.4.0.

