### PR TITLE
Make boto3 and pyarrow optional

### DIFF
--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -6,8 +6,13 @@ import re
 import subprocess
 from xml.etree import ElementTree
 
-import pyarrow
-from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
+
+try:
+    import pyarrow
+    from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
+except Exception:
+    # pyarrow is not available
+    pass
 
 from .fs import FS, FileStat
 

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -4,8 +4,12 @@ import os
 from types import TracebackType
 from typing import Optional, Type
 
-import boto3
-from botocore.exceptions import ClientError
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except Exception:
+    # boto3 is not available
+    pass
 
 from .fs import FS, FileStat
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
     extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.6",
-    install_requires=['pyarrow==4.0.0', 'boto3'],
     include_package_data=True,
     zip_safe=False,
 


### PR DESCRIPTION
Fixes #186

Please see #186 for the motivation. It's about pyarrow, but I think the same principle goes for S3 as well.