### PR TITLE
Fix text mode readlines

### DIFF
--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -33,13 +33,20 @@ def gen_fs(target):
 def test_smoke(target):
     filename = randstring()
     filename2 = randstring()
-    content = randstring(1024)
+    content = randstring(1024) + '\n' + randstring(234)
     with gen_fs(target) as fs:
         with fs.open(filename, 'w') as fp:
             fp.write(content)
 
         with fs.open(filename, 'r') as fp:
             assert content == fp.read()
+
+        with fs.open(filename, 'r') as fp:
+            lines = fp.readlines()
+            print(type(fp))
+            assert 2 == len(lines)
+            assert 1025 == len(lines[0])
+            assert 234 == len(lines[1])
 
         assert filename in list(fs.list())
 


### PR DESCRIPTION
@HiroakiMikami reported a bug where `readlines()` raises an undefined error.

```python
s3 = pfio.v2.S3(bucket)
with s3.open(os.path.join(prefix, "train.csv"), "r") as file:
    print(list(file.readlines()))
```
leads to 
```python
Traceback (most recent call last):
  File "preprocess/launcher/create_task_spec.py", line 62, in <module>
    main()
  File "preprocess/launcher/create_task_spec.py", line 58, in main
    run(seed, n_repository, bucket, prefix)
  File "preprocess/launcher/create_task_spec.py", line 16, in run
    print(list(file.readlines()))
  File "/foo/bar/python3.8/site-packages/pfio/v2/s3.py", line 50, in read
    r = 'bytes={}-{}'.format(s, e)
UnboundLocalError: local variable 'e' referenced before assignment
```