### PR TITLE
Fix RTFD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,8 @@ sphinx:
    configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-   - html
+# formats:
+#   - html
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
From RTFD:

```
Error
Problem in your project's configuration. Invalid "formats": expected one of (htmlzip, pdf, epub), got html
```