### PR TITLE
Fix bug in S3.list

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -368,7 +368,7 @@ class S3(FS):
         for res in iterator:
             # print(res)
             for common_prefix in res.get('CommonPrefixes', []):
-                yield common_prefix['Prefix']
+                yield common_prefix['Prefix'][len(key):]
             for content in res.get('Contents', []):
                 yield content['Key'][len(key):]
 

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -51,6 +51,12 @@ def test_s3():
             assert ['foo.txt'] == list(s3.list(recursive=True))
             assert ['base/foo.txt'] == list(s3.list('/', recursive=True))
 
+            with s3.open('dir/foo.txt', 'w') as fp:
+                fp.write('bar')
+                assert not fp.closed
+
+            assert ['dir/', 'foo.txt'] == list(s3.list())
+
             def f(s3):
                 try:
                     s3.open('foo.txt', 'r')


### PR DESCRIPTION
S3.list method returns relative path of the content keys, but returns entire key of the common-prefixes.
This PR make the API return relative path of the common prefixes.