### PR TITLE
Support O_DIRECT mode for cache files

### DIFF
--- a/pfio/cache/_file.py
+++ b/pfio/cache/_file.py
@@ -1,0 +1,7 @@
+import fcntl
+import os
+
+
+def set_o_direct(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_DIRECT)

--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -141,6 +141,9 @@ class FileCache(cache.Cache):
         o_direct (bool):
             Set O_DIRECT flag to the cache file. Setting this option
             ``True`` may fail depending on the filesystem e.g. tmpfs.
+            It may or may not fail on setting the option, but also
+            Throws ``OSError`` indicating ``EINVAL`` on writing or
+            reading data.
 
     '''
 

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -139,6 +139,13 @@ class MultiprocessFileCache(cache.Cache):
         verbose (bool):
             Print detailed logs of the cache.
 
+        o_direct (bool):
+            Set O_DIRECT flag to the cache file. Setting this option
+            ``True`` may fail depending on the filesystem e.g. tmpfs.
+            It may or may not fail on setting the option, but also
+            Throws ``OSError`` indicating ``EINVAL`` on writing or
+            reading data.
+
     '''  # NOQA
 
     def __init__(self, length, do_pickle=False, dir=None,

--- a/tests/cache_tests/test_file_cache.py
+++ b/tests/cache_tests/test_file_cache.py
@@ -1,18 +1,15 @@
 import tempfile
 
 import pytest
-from parameterized import parameterized
 
 import pfio
 from pfio.cache import FileCache, MultiprocessFileCache
 from pfio.testing import patch_subprocess
 
 
-@parameterized.expand([(True,), (False,)])
-def test_preservation_interoperability(o_direct):
-    with tempfile.TemporaryDirectory(dir='.') as d:
-        cache = FileCache(10, dir=d, do_pickle=True,
-                          o_direct=o_direct)
+def test_preservation_interoperability():
+    with tempfile.TemporaryDirectory() as d:
+        cache = FileCache(10, dir=d, do_pickle=True)
 
         for i in range(10):
             cache.put(i, str(i))
@@ -24,8 +21,7 @@ def test_preservation_interoperability(o_direct):
 
         cache.close()
 
-        cache2 = MultiprocessFileCache(10, dir=d, do_pickle=True,
-                                       o_direct=o_direct)
+        cache2 = MultiprocessFileCache(10, dir=d, do_pickle=True)
 
         assert cache2.preload('preserved') is True
         for i in range(10):

--- a/tests/cache_tests/test_file_cache.py
+++ b/tests/cache_tests/test_file_cache.py
@@ -1,15 +1,18 @@
 import tempfile
 
 import pytest
+from parameterized import parameterized
 
 import pfio
 from pfio.cache import FileCache, MultiprocessFileCache
 from pfio.testing import patch_subprocess
 
 
-def test_preservation_interoperability():
-    with tempfile.TemporaryDirectory() as d:
-        cache = FileCache(10, dir=d, do_pickle=True)
+@parameterized.expand([(True,), (False,)])
+def test_preservation_interoperability(o_direct):
+    with tempfile.TemporaryDirectory(dir='.') as d:
+        cache = FileCache(10, dir=d, do_pickle=True,
+                          o_direct=o_direct)
 
         for i in range(10):
             cache.put(i, str(i))
@@ -21,7 +24,8 @@ def test_preservation_interoperability():
 
         cache.close()
 
-        cache2 = MultiprocessFileCache(10, dir=d, do_pickle=True)
+        cache2 = MultiprocessFileCache(10, dir=d, do_pickle=True,
+                                       o_direct=o_direct)
 
         assert cache2.preload('preserved') is True
         for i in range(10):


### PR DESCRIPTION
Addresses #214 . Fortunately, both multiprocess and non-mp are supported (absolutely only for Linux).