### PR TITLE
Loader bench

### DIFF
--- a/loader-bench/README.md
+++ b/loader-bench/README.md
@@ -12,7 +12,9 @@ $ source bench/bin/activate
 Run micro-benchmark
 
 ```sh
-$ pip install -r requirements.txt
+$ cd pfio
+$ pip install -U -e .[bench]
+$ cd loader-bench
 $ time python3 main.py --preserve-path=/tmp/dat
 # Expected output example
 Namespace(batchsize=32, dataset_len=1024, num_trials=5, num_workers=8, preload_path=None, preserve_path='/tmp/dat')

--- a/loader-bench/README.md
+++ b/loader-bench/README.md
@@ -1,0 +1,38 @@
+# DataLoader benchmark of ppe-semseg
+
+## Quick start
+
+[Optional] Prepare [venv](https://docs.python.org/3/library/venv.html) not to make your environment dirty
+
+```sh
+$ python3 -m venv bench
+$ source bench/bin/activate
+```
+
+Run micro-benchmark
+
+```sh
+$ pip install -r requirements.txt
+$ time python3 main.py --preserve-path=/tmp/dat
+# Expected output example
+Namespace(batchsize=32, dataset_len=1024, num_trials=5, num_workers=8, preload_path=None, preserve_path='/tmp/dat')
+trial:  1, elapsed-time(all): 10.952 sec, ave-elapsed-time(img+label): 78.390 msec
+trial:  2, elapsed-time(all): 1.859 sec, ave-elapsed-time(img+label): 6.178 msec
+trial:  3, elapsed-time(all): 1.780 sec, ave-elapsed-time(img+label): 5.455 msec
+trial:  4, elapsed-time(all): 1.788 sec, ave-elapsed-time(img+label): 5.080 msec
+trial:  5, elapsed-time(all): 1.723 sec, ave-elapsed-time(img+label): 4.456 msec
+python3 main.py --preserve-path /tmp/dat  32.56s user 24.93s system 304% cpu 18.858 total
+$ time python3 main.py --preload-path=/tmp/dat  # If `/tmp/dat` already exists
+```
+
+The size of the preserved data should be around 3.6 GB when `dataset_len`=1024.
+
+## Generate smaller/larger dummy dataset
+
+`dataset_len` should be set to the multiples of `batchsize`.
+
+```sh
+$ export BATCHSIZE=19
+$ export DATASET_LEN=76
+$ python3 main.py --preserve-path=/tmp/dat_small --batchsize=${BATCHSIZE} --dataset_len=${DATASET_LEN}
+```

--- a/loader-bench/main.py
+++ b/loader-bench/main.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import argparse
+import io
+import os
+import time
+from typing import Any, Tuple
+
+import numpy as np
+import pfio
+import torch
+from torch.utils.data import Dataset
+from torch.utils.data.dataloader import DataLoader
+
+
+def index_to_rgb(index: int) -> Tuple[int, int, int]:
+    return index & 255, (index >> 8) & 255, (index >> 16) & 255
+
+
+def rgb_to_index(rgb: Any) -> int:
+    r, g, b = int(rgb[0]), int(rgb[1]), int(rgb[2])
+    return r | (g << 8) | (b << 16)
+
+
+def get_dummy_dataset(dataset_len: int, cache_path: str) -> Any:
+    return DummySemSegDataset(dataset_len, cache_path)
+
+
+class DummySemSegDataset(Dataset):
+    def __init__(self, dataset_len: int, cache_path: str) -> None:
+        self._dataset_len = dataset_len
+        cache_dir = os.path.dirname(cache_path)
+        self._cache = pfio.cache.MultiprocessFileCache(self._dataset_len, dir=cache_dir)
+
+    def _get_dummy_data(self, i: int) -> bytes:
+        img = np.ones((1280, 720, 3), dtype=np.uint8)
+        label = np.ones((1280, 720), dtype=np.uint8)
+        img[0, 0, :] = index_to_rgb(i)
+        ret = io.BytesIO()
+        # Loading data in .npz format is much slower than that of .npy format.
+        # The main overhead comes from `zlib.crc32` according to cProfile.
+        np.save(ret, img)
+        np.save(ret, label)
+        return ret.getvalue()
+
+    def __getitem__(self, index: int) -> Tuple[Any, Any, float]:
+        b_s = time.time()
+        data = self._cache.get_and_cache(index, self._get_dummy_data)
+        data_stream = io.BytesIO(data)
+        img = np.load(data_stream)
+        label = np.load(data_stream)
+        e_s = time.time()
+        return img, label, e_s - b_s
+
+    def __len__(self) -> int:
+        return self._dataset_len
+
+
+def benchmark(loader: Any) -> float:
+    etime_accum = 0.0
+    for _, _, etime in loader:
+        etime_accum += float(torch.sum(etime))
+    return etime_accum
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-len", default=1024, type=int)
+    parser.add_argument("--batchsize", default=32, type=int)
+    parser.add_argument("--num-workers", default=8, type=int)
+    parser.add_argument("--num-trials", default=5, type=int)
+    parser.add_argument(
+        "--preload-path", type=str, help="MultiprocessFileCache.preload"
+    )
+    parser.add_argument(
+        "--preserve-path", type=str, help="MultiprocessFileCache.preserve"
+    )
+    args = parser.parse_args()
+
+    if args.dataset_len >= 2 ** 24:
+        print("Too long --dataset-len")
+        exit()
+
+    def xor(lhs: str, rhs: str) -> int:
+        return (1 if lhs else 0) ^ (1 if rhs else 0)
+
+    if not xor(args.preload_path, args.preserve_path):
+        print("Specify either --preload-path or --preserve-path")
+        exit()
+
+    if args.preload_path:
+        if not os.path.exists(args.preload_path):
+            print(f"{args.preload_path} does not exist.")
+            exit()
+        cache_path = args.preload_path
+
+    if args.preserve_path:
+        if os.path.exists(args.preserve_path):
+            print(f"{args.preserve_path} already exists.")
+            exit()
+        cache_path = args.preserve_path
+
+    dummy_dataset = get_dummy_dataset(args.dataset_len, cache_path)
+
+    if args.preload_path:
+        dummy_dataset._cache.preload(args.preload_path)
+
+    loader = DataLoader(
+        dummy_dataset,
+        batch_size=args.batchsize,
+        drop_last=True,
+        num_workers=args.num_workers,
+        pin_memory=True,
+        shuffle=True,
+        persistent_workers=True,
+    )
+
+    if 1:
+        print(args)
+        for n in range(args.num_trials):
+            b_s = time.time()
+            etime_accum_s = benchmark(loader)
+            e_s = time.time()
+            etime_all_s = e_s - b_s
+            ave_etime_img_label_ms = etime_accum_s / args.dataset_len * 1000.0
+            print(
+                f"trial: {n + 1:2}, "
+                f"elapsed-time(all): {etime_all_s:.3f} sec, "
+                f"ave-elapsed-time(img+label): {ave_etime_img_label_ms:.3f} msec"
+            )
+    else:
+        # For debug
+        for n in range(args.num_trials):
+            print(f"{n} th")
+            indices = set()
+            for img, _ in loader:
+                for batch in range(args.batchsize):
+                    rgb = img[batch, 0, 0, :]
+                    indices.add(rgb_to_index(rgb))
+            assert len(indices) == args.dataset_len, "Mismatch"
+
+    if args.preserve_path:
+        dummy_dataset._cache.preserve(args.preserve_path, overwrite=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/loader-bench/main.py
+++ b/loader-bench/main.py
@@ -6,10 +6,11 @@ import time
 from typing import Any, Tuple
 
 import numpy as np
-import pfio
 import torch
 from torch.utils.data import Dataset
 from torch.utils.data.dataloader import DataLoader
+
+import pfio
 
 
 def index_to_rgb(index: int) -> Tuple[int, int, int]:

--- a/loader-bench/requirements.txt
+++ b/loader-bench/requirements.txt
@@ -1,0 +1,4 @@
+pfio==1.5.0
+numpy>=1.19.5
+torch>=1.9.0
+Pillow<=8.2.0

--- a/loader-bench/requirements.txt
+++ b/loader-bench/requirements.txt
@@ -1,4 +1,0 @@
-pfio==1.5.0
-numpy>=1.19.5
-torch>=1.9.0
-Pillow<=8.2.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
     extras_require={
         'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto'],
         # When updating doc deps, docs/requirements.txt should be updated too
-        'doc': ['sphinx', 'sphinx_rtd_theme']
+        'doc': ['sphinx', 'sphinx_rtd_theme'],
+        'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],
     },
     python_requires=">=3.6",
     # When updating install requires, docs/requirements.txt should be updated too


### PR DESCRIPTION
Add benchmark to compare cache class performance

```sh
$ time python3 main.py --preload-path ./dat
<class 'pfio.cache.multiprocess_file_cache.MultiprocessFileCache'>
Namespace(dataset_len=1024, batchsize=32, num_workers=8, num_trials=5, preload_path='./dat', preserve_path=None, cache_type='multiprocess')
trial:  1, elapsed-time(all): 3.061 sec, ave-elapsed-time(img+label): 1.352 msec
trial:  2, elapsed-time(all): 2.045 sec, ave-elapsed-time(img+label): 1.967 msec
trial:  3, elapsed-time(all): 1.953 sec, ave-elapsed-time(img+label): 2.072 msec
trial:  4, elapsed-time(all): 1.981 sec, ave-elapsed-time(img+label): 2.062 msec
trial:  5, elapsed-time(all): 1.951 sec, ave-elapsed-time(img+label): 2.114 msec

real    0m11.728s
user    0m28.036s
sys     0m37.290s
$ time python3 main.py --preload-path ./dat --cache-type "readonly"
Cache class: <class 'pfio.cache.mmap_file_cache.ReadOnlyFileCache'>
Namespace(dataset_len=1024, batchsize=32, num_workers=8, num_trials=5, preload_path='./dat', preserve_path=None, cache_type='readonly')
trial:  1, elapsed-time(all): 3.336 sec, ave-elapsed-time(img+label): 1.739 msec
trial:  2, elapsed-time(all): 1.949 sec, ave-elapsed-time(img+label): 1.737 msec
trial:  3, elapsed-time(all): 1.857 sec, ave-elapsed-time(img+label): 1.379 msec
trial:  4, elapsed-time(all): 1.873 sec, ave-elapsed-time(img+label): 1.396 msec
trial:  5, elapsed-time(all): 1.919 sec, ave-elapsed-time(img+label): 1.465 msec

real    0m11.703s
user    0m34.291s
sys     0m28.853s
$ time python3 main.py --preload-path ./dat --cache-type "file"
Cache class: <class 'pfio.cache.file_cache.FileCache'>
Namespace(dataset_len=1024, batchsize=32, num_workers=8, num_trials=5, preload_path='./dat', preserve_path=None, cache_type='file')
trial:  1, elapsed-time(all): 3.245 sec, ave-elapsed-time(img+label): 1.523 msec
trial:  2, elapsed-time(all): 1.862 sec, ave-elapsed-time(img+label): 1.587 msec
trial:  3, elapsed-time(all): 1.920 sec, ave-elapsed-time(img+label): 1.687 msec
trial:  4, elapsed-time(all): 1.959 sec, ave-elapsed-time(img+label): 1.892 msec
trial:  5, elapsed-time(all): 1.998 sec, ave-elapsed-time(img+label): 2.050 msec

real    0m11.727s
user    0m26.644s
sys     0m35.895s
```