### PR TITLE
Fix forkederror

### DIFF
--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -81,7 +81,6 @@ class FS(abc.ABC):
     '''
 
     _cwd = ''
-    pid = os.getpid()
 
     def __init__(self):
         self.pid = os.getpid()
@@ -133,6 +132,7 @@ class FS(abc.ABC):
 
     @property
     def is_forked(self):
+        assert hasattr(self, 'pid')
         return self.pid != os.getpid()
 
     def close(self) -> None:

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -288,6 +288,7 @@ class S3(FS):
                  aws_access_key_id=None,
                  aws_secret_access_key=None,
                  mpu_chunksize=32*1024*1024):
+        super().__init__()
         self.bucket = bucket
         if prefix is not None:
             self.cwd = prefix

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -76,6 +76,21 @@ def test_s3():
             p.join()
             assert p.exitcode == 0
 
+            def g(s3):
+                try:
+                    with S3(bucket='test-dummy-bucket',
+                            aws_access_key_id=key,
+                            aws_secret_access_key=secret) as s4:
+                        with s4.open('base/foo.txt', 'r') as fp:
+                            fp.read()
+                except ForkedError:
+                    pytest.fail('ForkedError')
+
+            p = mp.Process(target=g, args=(s3,))
+            p.start()
+            p.join()
+            assert p.exitcode == 0
+
 
 @mock_s3
 def test_s3_mpu():


### PR DESCRIPTION
Internally reported bug

The source of bug was to set class-bound member `.pid` in all `FS`-inherited classes and objects; for `S3`, `lazify` and `._check_forked()` always throw ForkedError as it's always returns class-bound member pid of parent process.