### PR TITLE
`xml.etree.ElementTree.Element.getchildren` is abolished in python 3.9

### DIFF
--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -150,7 +150,7 @@ def _create_fs():
     configs = {}
     for e in root.findall('./property'):
         name = None
-        for c in e.getchildren():
+        for c in e:
             if c.tag == 'name':
                 name = c.text
             elif c.tag == 'value':


### PR DESCRIPTION
When accessing HDFS using pfio==2.0.0 with Python 3.9 environment, it immediately raises the following error.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/contextlib.py", line 119, in __enter__
    return next(self.gen)
  File "/usr/local/lib/python3.9/site-packages/pfio/v2/fs.py", line 293, in open_url
    with from_url(dirname, **kwargs) as fs:
  File "/usr/local/lib/python3.9/site-packages/pfio/v2/fs.py", line 350, in from_url
    fs = _from_scheme(scheme, dirname, kwargs, bucket=parsed.netloc)
  File "/usr/local/lib/python3.9/site-packages/pfio/v2/fs.py", line 365, in _from_scheme
    fs = Hdfs(dirname, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/pfio/v2/hdfs.py", line 185, in __init__
    self._fs = _create_fs()
  File "/usr/local/lib/python3.9/site-packages/pfio/v2/hdfs.py", line 153, in _create_fs
    for c in e.getchildren():
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
```

This is because configuration parse process calls an abolished function.
https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren
https://github.com/pfnet/pfio/blob/2.0.0/pfio/v2/hdfs.py#L153

This PR fixes this issue.
I confirmed the it also works with Python 3.8 environment as well as 3.9.