### PR TITLE
Provide 'create' option in each filesystem (v2 API)

### DIFF
--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -4,7 +4,7 @@ import copy
 import os
 import stat
 from abc import abstractmethod
-from io import IOBase, UnsupportedOperation
+from io import IOBase
 from types import TracebackType
 from typing import Any, Callable, Iterator, Optional, Type
 from urllib.parse import urlparse
@@ -335,7 +335,7 @@ def from_url(url: str, **kwargs) -> 'FS':
     def _zip_check_create_not_supported():
         if kwargs.get('create', False):
             msg = '"create" option is not supported for Zip FS.'
-            raise UnsupportedOperation(msg)
+            raise ValueError(msg)
 
     # force_type \ suffix | .zip    | other
     # --------------------+---------+------

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -313,6 +313,8 @@ def from_url(url: str, **kwargs) -> 'FS':
             One of "zip", "hdfs", "s3", or "file", returned
             respectively. Default is ``"file"``.
 
+        create (bool): Create the specified path doesn't exist.
+
     .. note:: Some FS resouces won't be closed when using this
         functionality.
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -4,7 +4,7 @@ import copy
 import os
 import stat
 from abc import abstractmethod
-from io import IOBase
+from io import IOBase, UnsupportedOperation
 from types import TracebackType
 from typing import Any, Callable, Iterator, Optional, Type
 from urllib.parse import urlparse
@@ -332,18 +332,25 @@ def from_url(url: str, **kwargs) -> 'FS':
         if force_type != scheme:
             raise ValueError("URL scheme mismatch with forced type")
 
+    def _zip_check_create_not_supported():
+        if kwargs.get('create', False):
+            msg = '"create" option is not supported for Zip FS.'
+            raise UnsupportedOperation(msg)
+
     # force_type \ suffix | .zip    | other
     # --------------------+---------+------
     #                 zip | ok      | try zip
     #             (other) | try dir | try dir
     #                None | try zip | try dir
     if force_type == 'zip':
+        _zip_check_create_not_supported()
         dirname, filename = os.path.split(parsed.path)
         fs = _from_scheme(scheme, dirname, kwargs, bucket=parsed.netloc)
         fs = fs.open_zip(filename)
 
     elif force_type is None:
         if parsed.path.endswith('.zip'):
+            _zip_check_create_not_supported()
             dirname, filename = os.path.split(parsed.path)
             fs = _from_scheme(scheme, dirname, kwargs, bucket=parsed.netloc)
             fs = fs.open_zip(filename)

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -180,7 +180,7 @@ class Hdfs(FS):
 
     '''
 
-    def __init__(self, cwd=None, **_):
+    def __init__(self, cwd=None, create=False, **_):
         super().__init__()
         self._fs = _create_fs()
         assert self._fs is not None
@@ -194,7 +194,11 @@ class Hdfs(FS):
             else:
                 self.cwd = os.path.join(self.cwd, cwd)
 
-        assert self.isdir('')
+        if not self.isdir(''):
+            if create:
+                self.makedirs('')
+            else:
+                raise ValueError('{} must be a directory'.format(self.cwd))
 
     def _get_principal_name(self):
         # get the default principal name from `klist` cache

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -43,7 +43,7 @@ class LocalFileStat(FileStat):
 
 
 class Local(FS):
-    def __init__(self, cwd=None, **_):
+    def __init__(self, cwd=None, create=False, **_):
         super().__init__()
 
         if cwd is None:
@@ -52,7 +52,10 @@ class Local(FS):
             self._cwd = cwd
 
         if not self.isdir(''):
-            raise ValueError('{} must be a directory'.format(self._cwd))
+            if create:
+                os.makedirs(self._cwd)
+            else:
+                raise ValueError('{} must be a directory'.format(self._cwd))
 
     @property
     def cwd(self):

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -306,6 +306,7 @@ class S3(FS):
                  aws_secret_access_key=None,
                  mpu_chunksize=32*1024*1024,
                  buffering=-1,
+                 create=False,
                  **_):
         super().__init__()
         self.bucket = bucket
@@ -313,6 +314,9 @@ class S3(FS):
             self.cwd = prefix
         else:
             self.cwd = ''
+
+        # In S3, create flag can be disregarded
+        del create
 
         self.mpu_chunksize = mpu_chunksize
         self.buffering = buffering

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -52,11 +52,14 @@ class ZipFileStat(FileStat):
 class Zip(FS):
     _readonly = True
 
-    def __init__(self, backend, file_path, mode='r', **_):
+    def __init__(self, backend, file_path, mode='r', create=False, **_):
         super().__init__()
         self.backend = backend
         self.file_path = file_path
         self.mode = mode
+
+        if create:
+            raise io.UnsupportedOperation("create option is not supported")
 
         if 'r' in mode and 'w' in mode:
             raise io.UnsupportedOperation('Read-write mode is not supported')

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -59,7 +59,7 @@ class Zip(FS):
         self.mode = mode
 
         if create:
-            raise io.UnsupportedOperation("create option is not supported")
+            raise ValueError("create option is not supported")
 
         if 'r' in mode and 'w' in mode:
             raise io.UnsupportedOperation('Read-write mode is not supported')

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -1,6 +1,5 @@
 # Test fs.FS compatibility
 import contextlib
-import io
 import multiprocessing as mp
 import os
 import tempfile
@@ -10,7 +9,7 @@ from moto import mock_s3
 from parameterized import parameterized
 
 from pfio.testing import ZipForTest, randstring
-from pfio.v2 import S3, Hdfs, Local, Zip, from_url, lazify, open_url
+from pfio.v2 import S3, Local, Zip, from_url, lazify, open_url
 
 
 @contextlib.contextmanager
@@ -97,78 +96,7 @@ def test_smoke(target):
         assert subfs.exists('foo')
 
 
-@mock_s3
-def test_factory_open():
-    assert isinstance(from_url('.'), Local)
-    with open_url('./setup.cfg') as fp:
-        assert isinstance(fp, io.IOBase)
-
-    bucket = 'foobar'
-    with S3(bucket, create_bucket=True) as s3:
-        with s3.open('baz.txt', 'w') as fp:
-            fp.write('bom')
-
-        with s3.open('baz.txt', 'r') as fp:
-            assert 'bom' == fp.read()
-
-    assert isinstance(from_url('s3://foobar/boom/bom'), S3)
-
-    with open_url('s3://foobar/boom/bom.txt', 'w') as fp:
-        fp.write('hello')
-
-    with open_url('s3://foobar/boom/bom.txt', 'r') as fp:
-        assert 'hello' == fp.read()
-
-    with from_url('s3://foobar/') as fs:
-        assert isinstance(fs, S3)
-
-    with from_url('s3://foobar/path/') as fs:
-        assert isinstance(fs, S3)
-
-
-@mock_s3
-def test_from_url_create_option():
-    # posix filesystem
-    with tempfile.TemporaryDirectory() as d:
-        path = os.path.join(d, 'non-existent-directory')
-        with pytest.raises(ValueError):
-            from_url(path)
-
-        from_url(path, create=True)
-        assert os.path.exists(path) and os.path.isdir(path)
-
-    # HDFS
-    hdfs = Hdfs()
-    path = os.path.join(hdfs.cwd, randstring())
-    url = 'hdfs://{}'.format(path)
-    with pytest.raises(ValueError):
-        fs = from_url(url)
-
-    fs = from_url(url, create=True)
-    assert fs.exists(path)
-
-    hdfs.remove(path, recursive=True)
-    hdfs.close()
-
-    # With S3, create option has no effect
-    bucket = "test-dummy-bucket"
-    with S3(bucket, create_bucket=True):
-        path = 's3://{}/path/'.format(bucket)
-        fs = from_url(path)
-        assert not fs.exists(path)
-
-        fs = from_url(path, create=True)
-        assert not fs.exists(path)
-
-    # With ZIP, create option raises an error
-    with pytest.raises(ValueError):
-        from_url('/foobar.zip', create=True)
-
-    with pytest.raises(ValueError):
-        from_url('/foobar.zip', create=True, force_type='zip')
-
-
-def test_force_type():
+def test_from_url_force_type():
     with from_url(".", force_type='file') as fs:
         assert isinstance(fs, Local)
 

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -10,7 +10,7 @@ from moto import mock_s3
 from parameterized import parameterized
 
 from pfio.testing import ZipForTest, randstring
-from pfio.v2 import Hdfs, Local, S3, Zip, from_url, lazify, open_url
+from pfio.v2 import S3, Hdfs, Local, Zip, from_url, lazify, open_url
 
 
 @contextlib.contextmanager

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -161,10 +161,10 @@ def test_from_url_create_option():
         assert not fs.exists(path)
 
     # With ZIP, create option raises an error
-    with pytest.raises(io.UnsupportedOperation):
+    with pytest.raises(ValueError):
         from_url('/foobar.zip', create=True)
 
-    with pytest.raises(io.UnsupportedOperation):
+    with pytest.raises(ValueError):
         from_url('/foobar.zip', create=True, force_type='zip')
 
 

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -15,7 +15,8 @@ import pytest
 from parameterized import parameterized
 
 from pfio.testing import ZipForTest, make_random_str, make_zip
-from pfio.v2 import ZipFileStat, local
+from pfio.v2 import ZipFileStat, from_url, local
+from pfio.v2.zip import Zip
 
 ZIP_TEST_FILENAME_LIST = {
     "dir_name1": "testdir1",
@@ -520,6 +521,23 @@ class TestZip(unittest.TestCase):
             with self.assertRaises(ValueError):
                 with z.open(testfile_name, "w") as zipped_file:
                     zipped_file.write(test_string)
+
+    def test_fs_factory(self):
+        with from_url(os.path.abspath(self.zip_file_path)) as fs:
+            assert isinstance(fs, Zip)
+            assert fs.isdir('testdir2')
+            assert fs.exists('testdir2/testfile1')
+            assert fs.exists('testfile2')
+
+            with fs.open('testfile2', 'r') as f:
+                assert f.read() == 'this is a test string\n'
+
+    def test_from_url_create_option(self):
+        with pytest.raises(ValueError):
+            from_url('/foobar.zip', create=True)
+
+        with pytest.raises(ValueError):
+            from_url('/foobar.zip', create=True, force_type='zip')
 
 
 class TestZipWithLargeData(unittest.TestCase):


### PR DESCRIPTION
I'd like to have a discussion on adding the `create` option to `from_url`, which I propose a PoC implementation in this PR.

### What is done in this PR
In the current `from_url` (specifically in local and HDFS filesytems), path to a non-existent directory is not accepted.
```python
>>> pfio.v2.from_url("/path/to/non/existent/dir")
ValueError: /path/to/non/existent/directory must be a directory
```

In this PR, I implemented `create` option to  each filesystem:
- `Local` and `HDFS`: When True and if the specified path doesn't exist, it creates the directory
- `S3`: Just ignores
- `Zip`: When True and the specified zip doesn't exist, it raises an error

This allows us to call `from_url` like this:

```python
>>> with pfio.v2.from_url("/path/to/non/existent/dir", create=True) as fs:
... 
>>> os.path.isdir("/path/to/non/existent/dir")
True
```
(Same for HDFS).


### Background

pfio provides so powerful filesystem-agnostic API that we can treat an arbitrary filesytem (`pfio.v2.FS` object) as a portable IO handler to save things, instead of directly using native `open` and `write`.

```python
# A very simple toy example of a native-filesystem dependent data saver.
def save_array(ar, full_path):
    with open(full_path, 'wb') as f:
        np.save(f, ar)

save_array(ar, "/path/to/data.npy")

# A toy filesystem-agnostic saver, which is cool
def save_array(ar, fs, rel_path):
    fs.open(rel_path, "wb") as f:
        np.save(f, ar)

with pfio.v2.from_url("hdfs:///xxx/yyy/dir") as fs:
    save_array(ar, fs, "data.npy")
```

In this way of use, there would be a situation where we want to specify a non-existent directory to `from_url`. In such a case we'd expect `from_url` (or such a saver method) to create the destination if it doesn't exist, but as I mentioned earlier `from_url` doesn't accept it. Specifying an non-existent directory as an output destination (to be created) is a very common idiom that can be seen in various places, so I want to realize the same thing with `from_url`.

\# In that sense, maybe the above toy examples weren't good - in order to save just one file, the proposed `create` option won't sound so much beneficial. When we need to save many files into a directory, the proposed feature becomes more practically useful e.g., training snapshots in deep learning workloads using pytorch-pfn-extras writing abstraction.
https://pytorch-pfn-extras.readthedocs.io/en/latest/reference/generated/pytorch_pfn_extras.training.extensions.snapshot.html