### PR TITLE
Fix `pfio.v2.Hdfs.isdir` returns `True` to non-existent path

### DIFF
--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -274,7 +274,7 @@ class Hdfs(FS):
         self._checkfork()
         path = os.path.join(self.cwd, path)
         info = self._fs.get_file_info(path)
-        return not info.is_file
+        return info.type == FileType.Directory
 
     def mkdir(self, path: str, *args, dir_fd=None):
         self._checkfork()

--- a/tests/v2_tests/test_hdfs.py
+++ b/tests/v2_tests/test_hdfs.py
@@ -284,6 +284,7 @@ class TestHdfsFsWithFile(unittest.TestCase):
         with Hdfs() as fs:
             self.assertTrue(fs.isdir("/"))
             self.assertFalse(fs.isdir(self.tmpfile_name))
+            self.assertFalse(fs.isdir("/nonexistent-entity"))
 
     def test_exists(self):
         non_exist_file = "non_exist_file.txt"


### PR DESCRIPTION
In HDFS filesytem of the v2 API in `pfio==2.0.1`, `isdir` method returns `True` in case the specified path doesn't exist.
```bash
>>> fs = pfio.v2.from_url('hdfs:///user/<user>/')
>>> fs.isdir('this-does-not-exist')
True
```

This PR fixes it.