### PR TITLE
Buffered S3 reader

### DIFF
--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -180,7 +180,7 @@ class Hdfs(FS):
 
     '''
 
-    def __init__(self, cwd=None):
+    def __init__(self, cwd=None, **_):
         super().__init__()
         self._fs = _create_fs()
         assert self._fs is not None

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -43,8 +43,9 @@ class LocalFileStat(FileStat):
 
 
 class Local(FS):
-    def __init__(self, cwd=None):
+    def __init__(self, cwd=None, **_):
         super().__init__()
+
         if cwd is None:
             self._cwd = ''
         else:

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -305,7 +305,8 @@ class S3(FS):
                  aws_access_key_id=None,
                  aws_secret_access_key=None,
                  mpu_chunksize=32*1024*1024,
-                 buffering=-1):
+                 buffering=-1,
+                 **_):
         super().__init__()
         self.bucket = bucket
         if prefix is not None:

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -40,8 +40,10 @@ class S3PrefixStat(FileStat):
         return True
 
 
-class _ObjectReader:
+class _ObjectReader(io.RawIOBase):
     def __init__(self, client, bucket, key, mode, kwargs):
+        super(_ObjectReader, self).__init__()
+
         self.client = client
         self.bucket = bucket
         self.key = key
@@ -140,6 +142,15 @@ class _ObjectReader:
 
     def write(self, data):
         raise io.UnsupportedOperation('not writable')
+
+    def readall(self):
+        self.seek(0)
+        return self.read(-1)
+
+    def readinto(self, b):
+        buf = self.read(len(b))
+        b[:len(buf)] = buf
+        return len(buf)
 
 
 class _ObjectWriter:

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -9,7 +9,6 @@ from botocore.exceptions import ClientError
 
 from .fs import FS, FileStat
 
-
 DEFAULT_MAX_BUFFER_SIZE = 16 * 1024 * 1024
 
 

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -10,6 +10,9 @@ from botocore.exceptions import ClientError
 from .fs import FS, FileStat
 
 
+DEFAULT_BUFFER_SIZE = 32 * 1024 * 1024
+
+
 def _normalize_key(key: str) -> str:
     key = os.path.normpath(key)
     if key.startswith("/"):
@@ -367,9 +370,7 @@ class S3(FS):
         if 'r' in mode:
             obj = _ObjectReader(self.client, self.bucket, path, mode, kwargs)
             if 'b' in mode:
-                # TODO: BufferedIOBase requires readinto() implemeted
-                # obj = io.BufferedReader(obj)
-                pass
+                obj = io.BufferedReader(obj, buffer_size=DEFAULT_BUFFER_SIZE)
             else:
                 obj = io.TextIOWrapper(obj)
 

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -147,7 +147,6 @@ class _ObjectReader(io.RawIOBase):
         raise io.UnsupportedOperation('not writable')
 
     def readall(self):
-        self.seek(0)
         return self.read(-1)
 
     def readinto(self, b):

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -52,7 +52,7 @@ class ZipFileStat(FileStat):
 class Zip(FS):
     _readonly = True
 
-    def __init__(self, backend, file_path, mode='r', cwd=None):
+    def __init__(self, backend, file_path, mode='r', **_):
         super().__init__()
         self.backend = backend
         self.file_path = file_path

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -79,6 +79,7 @@ def test_s3_files(s3_fixture):
         assert not s3.isdir("/bas")
 
 
+# TODO: Find out a way to know buffer size used in a BufferedReader
 @pytest.mark.parametrize("buffering, reader_type",
                          [(-1, io.BufferedReader),
                           (0, _ObjectReader),


### PR DESCRIPTION
This tries to fix #241 .

## What is done in this PR

Main purpose is to provide buffering in S3 reader.

As left in the TODO comment [here](https://github.com/pfnet/pfio/blob/2.0.1/pfio/v2/s3.py#L359), `_ObjectReader` provided insufficient feature in order to use with [`io.BufferedReader`](https://docs.python.org/ja/3/library/io.html#io.BufferedReader).
In this PR I implemented `readall` and `readinto` methods that will be called from `BufferedReader`  in `_ObjectReader`, and make it subclass of `io.RawIOBase`.

This is basically same as how normal filesystem is handled in Python; `open("xxxx", "rb")` returns a `BufferedReader`, whose original stream is a `FileIO` (unbuffered raw stream for local files) object.

There are also several works included.
* Add kwargs `**_` trap to each filesystem.
    * `S3` accepts `"buffering"` and some other options in `open_url` and `from_url`. Similarly other filesystem may have their specific arguments. An option for a specific filesystem type will cause of "an unexpected keyword argument". This makes `open_url` or `from_url` call filesystem dependent, which hurts pfio transparency power.
    * By adding `**_` to `__init__` of each filesystem, it can simply ignore unsupported argument t
    * The downside would be:
        * Code readability. I need to provide sufficient document
        * Debuggability (e.g., typo): ??
* Slightly reorganized tests
    * I split some of existing test cases in accordance with their test purpose, to test them clearly with and without buffering.

## Usage

```python
>>> with pfio.v2.from_url("s3://<bucket>/") as fs:
...     fs.open("foo.dat")  <---- It returns a BufferedReader (which wraps `_ObjectReader`)
>>> with pfio.v2.open_url("s3://<bucket>/", "rb") as f:
...     f   <------- It is also a `BufferedReader`
```

The buffering can be controlled by `buffering` option in `__init__` (suggested by https://github.com/pfnet/pfio/pull/247#issuecomment-1001420431),
- `buffering=0`: No buffering
- `buffering=-1` (default): Use the default buffer size of 32MiB
- `buffering>0`: Use the specified value (integer) as the buffer size

`buffering` option can be passed to `from_url` and `open_url`.

```python
>>> with pfio.v2.from_url("s3://<bucket>/", buffering=0) as fs:
...     fs.open("foo.dat")  <---- It'll be an `_ObjectReader`
>>> with pfio.v2.open_url("s3://<bucket>/", "rb", buffering=0) as f:
...     f   <------- It is also a `_ObjectReader`
```

Buffering option has no effect when opening a file in text mode or write mode.


## Performance
I confirmed a significant speedup when loading the same test data (a PIL image) as #241 .

**pfio 2.0.1 (brought  from #241)**
```python
>>> %%time
>>> with pfio.v2.open_url('s3://<bucket>/DSC07917.jpg', 'rb') as f:
...     print(PIL.Image.open(f).size)
(2626, 1776)
CPU times: user 642 ms, sys: 56.5 ms, total: 698 ms
Wall time: 2.22 s
```

**pfio 2.0.1 with BytesIO (brought  from #241 as well)**
```python
>>> %%time
>>> with pfio.v2.open_url('s3://<bucket>/DSC07917.jpg', 'rb') as f:
...     print(PIL.Image.open(io.BytesIO(f.read())).size)
(2626, 1776)
CPU times: user 46.9 ms, sys: 0 ns, total: 46.9 ms
Wall time: 108 ms
```

**This PR**
```python
>>> %%time
>>> with pfio.v2.open_url('s3://<bucket>/DSC07917.jpg', 'rb') as f:
...     print(PIL.Image.open(f).size)
(2626, 1776)
CPU times: user 51.5 ms, sys: 0 ns, total: 51.5 ms
Wall time: 115 ms
```

Thanks to the buffering, now it performs very similar speed to the `BytesIO` workaround.

## Discussion

I set buffer size 32MiB to `pfio.v2.s3.DEFAULT_BUFFER_SIZE`.

When handling local (posix) files, Python uses 8192 bytes as the default buffer size ((`io.DEFAULT_BUFFER_SIZE`](https://docs.python.org/3/library/io.html#io.DEFAULT_BUFFER_SIZE)).
However for S3 since HTTP overhead is the way larger than native filesystem, the buffer size should be much larger for efficiency. I thought 32MiB would be a good balance, but maybe it's better to do some sort of micro-benchmarks.

If you suggest some specific values or way to identify the best number, please make an advice 🙇.

## Another content

`_ObjectReader.readall` was implemented as follows:
```python
    def readall(self):
        self.seek(0)         <---------
        return self.read(-1)
```

However this behavior (specifically, seeking to the head as shown as an arrow above) is inconsistent to normal filesystems.

```python
>>> f = open('hoge.dat', 'rb')
>>> print(f.read())
>>> f.seek(5, os.SEEK_SET)
>>> print('tell() =', f.raw.tell())
>>> print(f.raw.readall())
b'0123456789'
tell() = 5
b'56789'
```

This behavior prevented the buffering to work properly, this PR fixes it too.


## References

Python official document provides by far insufficient information. These resources helped me a lot learning how/what to implement in `readinto`.
* https://stackoverflow.com/a/45805325
* https://github.com/python/cpython/blob/3.9/Lib/_pyio.py#L1165-L1222