### PR TITLE
Fix `S3.rename` didn't correctly remove the old file

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -520,7 +520,7 @@ class S3(FS):
         if not res.get('CopyObjectResult'):
             # copy failed
             return
-        return self.remove(source.get('Key'))
+        return self.remove(src)
 
     def remove(self, file_path: str, recursive=False):
         '''Removes an object

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -525,9 +525,14 @@ class S3(FS):
     def remove(self, file_path: str, recursive=False):
         '''Removes an object
 
+        It raises a FileNotFoundError when the specified file doesn't exist.
         '''
         if recursive:
             raise io.UnsupportedOperation("Recursive delete not supported")
+
+        if not self.exists(file_path):
+            msg = "No such S3 object: '{}'".format(file_path)
+            raise FileNotFoundError(msg)
 
         self._checkfork()
         key = os.path.join(self.cwd, file_path)

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -10,100 +10,106 @@ from pfio.v2 import S3, from_url, open_url
 from pfio.v2.fs import ForkedError
 
 
-@mock_s3
-def test_s3():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
-            assert bucket == s3.bucket
-            assert '/base' == s3.cwd
-            assert key == s3.aws_access_key_id
-            assert secret == s3.aws_secret_access_key
-            assert s3.endpoint is None
+@pytest.fixture
+def s3_fixture():
+    # A test fixture which provides
+    # - S3 mock. using this fixture is equivalent to using @mock_s3 decorator
+    # - Dummy credentials
+    # - S3 filesystem with bucket creation
+    with mock_s3():
+        class _S3Fixture():
+            bucket = "test-bucket"
+            aws_kwargs = {
+                "aws_access_key_id": "it's me!deadbeef",
+                "aws_secret_access_key": "asedf;lkjdf;a'lksjd",
+            }
+            fs = S3(bucket, create_bucket=True)
 
-            with s3.open('foo.txt', 'w') as fp:
-                fp.write('bar')
-                assert not fp.closed
-
-            with s3.open('foo.txt', 'r') as fp:
-                assert 'bar' == fp.read()
-                assert not fp.closed
-
-            with s3.open('foo.txt', 'rb') as fp:
-                assert b'b' == fp.read(1)
-                assert b'a' == fp.read(1)
-                assert b'r' == fp.read(1)
-                assert b'' == fp.read(1)
-                assert b'' == fp.read(1)
-                fp.seek(1)
-                assert b'a' == fp.read(1)
-                assert b'r' == fp.read(1)
-                assert b'' == fp.read(1)
-                assert not fp.closed
-
-            assert ['foo.txt'] == list(s3.list())
-            assert [] == list(s3.list('base'))
-            assert [] == list(s3.list('base/'))
-            assert ['foo.txt'] == list(s3.list('/base'))
-            assert ['foo.txt'] == list(s3.list('/base/'))
-
-            assert ['foo.txt'] == list(s3.list(recursive=True))
-            assert ['base/foo.txt'] == list(s3.list('/', recursive=True))
-
-            with s3.open('dir/foo.txt', 'w') as fp:
-                fp.write('bar')
-                assert not fp.closed
-
-            assert ['dir/', 'foo.txt'] == list(s3.list())
-
-            assert not s3.isdir("foo.txt")
-            assert s3.isdir(".")
-            assert s3.isdir("/base/")
-            assert s3.isdir("/base")
-            assert not s3.isdir("/bas")
-
-            def f(s3):
-                try:
-                    s3.open('foo.txt', 'r')
-                except ForkedError:
-                    pass
-                else:
-                    pytest.fail('No Error on Forking')
-
-            p = mp.Process(target=f, args=(s3,))
-            p.start()
-            p.join()
-            assert p.exitcode == 0
-
-            def g(s3):
-                try:
-                    with S3(bucket='test-dummy-bucket',
-                            aws_access_key_id=key,
-                            aws_secret_access_key=secret) as s4:
-                        with s4.open('base/foo.txt', 'r') as fp:
-                            fp.read()
-                except ForkedError:
-                    pytest.fail('ForkedError')
-
-            p = mp.Process(target=g, args=(s3,))
-            p.start()
-            p.join()
-            assert p.exitcode == 0
+        yield _S3Fixture()
 
 
-@mock_s3
-def test_s3_mpu():
+def test_s3(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
+        assert s3_fixture.bucket == s3.bucket
+        assert '/base' == s3.cwd
+        assert s3_fixture.aws_kwargs['aws_access_key_id'] \
+            == s3.aws_access_key_id
+        assert s3_fixture.aws_kwargs['aws_secret_access_key'] \
+            == s3.aws_secret_access_key
+        assert s3.endpoint is None
+
+        with s3.open('foo.txt', 'w') as fp:
+            fp.write('bar')
+            assert not fp.closed
+
+        with s3.open('foo.txt', 'r') as fp:
+            assert 'bar' == fp.read()
+            assert not fp.closed
+
+        with s3.open('foo.txt', 'rb') as fp:
+            assert b'b' == fp.read(1)
+            assert b'a' == fp.read(1)
+            assert b'r' == fp.read(1)
+            assert b'' == fp.read(1)
+            assert b'' == fp.read(1)
+            fp.seek(1)
+            assert b'a' == fp.read(1)
+            assert b'r' == fp.read(1)
+            assert b'' == fp.read(1)
+            assert not fp.closed
+
+        assert ['foo.txt'] == list(s3.list())
+        assert [] == list(s3.list('base'))
+        assert [] == list(s3.list('base/'))
+        assert ['foo.txt'] == list(s3.list('/base'))
+        assert ['foo.txt'] == list(s3.list('/base/'))
+
+        assert ['foo.txt'] == list(s3.list(recursive=True))
+        assert ['base/foo.txt'] == list(s3.list('/', recursive=True))
+
+        with s3.open('dir/foo.txt', 'w') as fp:
+            fp.write('bar')
+            assert not fp.closed
+
+        assert ['dir/', 'foo.txt'] == list(s3.list())
+
+        assert not s3.isdir("foo.txt")
+        assert s3.isdir(".")
+        assert s3.isdir("/base/")
+        assert s3.isdir("/base")
+        assert not s3.isdir("/bas")
+
+        def f(s3):
+            try:
+                s3.open('foo.txt', 'r')
+            except ForkedError:
+                pass
+            else:
+                pytest.fail('No Error on Forking')
+
+        p = mp.Process(target=f, args=(s3,))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+
+        def g(s3):
+            try:
+                with S3(bucket='test-bucket', **s3_fixture.aws_kwargs) as s4:
+                    with s4.open('base/foo.txt', 'r') as fp:
+                        fp.read()
+            except ForkedError:
+                pytest.fail('ForkedError')
+
+        p = mp.Process(target=g, args=(s3,))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+
+
+def test_s3_mpu(s3_fixture):
     # Test multipart upload
-    bucket = 'test-mpu'
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True, mpu_chunksize=8*1024*1024,
-            aws_access_key_id=key,
-            aws_secret_access_key=secret) as s3:
+    with S3(s3_fixture.bucket, create_bucket=True, mpu_chunksize=8*1024*1024,
+            **s3_fixture.aws_kwargs) as s3:
         with s3.open('testfile', 'wb') as fp:
             for _ in range(4):
                 fp.write(b"01234567" * (1024*1024))
@@ -142,25 +148,18 @@ def touch(s3, path, content):
     assert s3.exists(path)
 
 
-@mock_s3
-def test_s3_recursive():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
+def test_s3_recursive(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
 
-            touch(s3, 'foo.txt', 'bar')
-            touch(s3, 'bar.txt', 'baz')
-            touch(s3, 'baz/foo.txt', 'foo')
+        touch(s3, 'foo.txt', 'bar')
+        touch(s3, 'bar.txt', 'baz')
+        touch(s3, 'baz/foo.txt', 'foo')
 
-            assert 3 == len(list(s3.list(recursive=True)))
-            abspaths = list(s3.list('/', recursive=True))
-            assert 3 == len(abspaths)
-            for p in abspaths:
-                assert p.startswith('base/')
+        assert 3 == len(list(s3.list(recursive=True)))
+        abspaths = list(s3.list('/', recursive=True))
+        assert 3 == len(abspaths)
+        for p in abspaths:
+            assert p.startswith('base/')
 
 
 def _seek_check(f):
@@ -201,23 +200,15 @@ def _seek_check(f):
     assert f.tell() == 12, "the position should be kept after an error"
 
 
-@mock_s3
-def test_s3_seek():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
+def test_s3_seek(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
 
-            # Make a 10-bytes test data
-            touch(s3, 'foo.data', '0123456789')
+        # Make a 10-bytes test data
+        touch(s3, 'foo.data', '0123456789')
 
-        with open_url('s3://test-dummy-bucket/base/foo.data', 'rb',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as f:
-            _seek_check(f)
+    with open_url('s3://test-bucket/base/foo.data', 'rb',
+                  **s3_fixture.aws_kwargs) as f:
+        _seek_check(f)
 
     # Make sure the seek behavior is same as normal file-like objects.
     with tempfile.NamedTemporaryFile() as tmpf:
@@ -230,45 +221,29 @@ def test_s3_seek():
             _seek_check(f)
 
 
-@mock_s3
-def test_s3_pickle():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
+def test_s3_pickle(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
 
-            with s3.open('foo.pkl', 'wb') as fp:
-                pickle.dump({'test': 'data'}, fp)
+        with s3.open('foo.pkl', 'wb') as fp:
+            pickle.dump({'test': 'data'}, fp)
 
-        with open_url('s3://test-dummy-bucket/base/foo.pkl', 'rb',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as f:
-            assert pickle.load(f) == {'test': 'data'}
+    with open_url('s3://test-bucket/base/foo.pkl', 'rb',
+                  **s3_fixture.aws_kwargs) as f:
+        assert pickle.load(f) == {'test': 'data'}
 
 
-@mock_s3
-def test_rename():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
+def test_rename(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
 
-            with s3.open('foo.pkl', 'wb') as fp:
-                pickle.dump({'test': 'data'}, fp)
+        with s3.open('foo.pkl', 'wb') as fp:
+            pickle.dump({'test': 'data'}, fp)
 
-            s3.rename('foo.pkl', 'bar.pkl')
+        s3.rename('foo.pkl', 'bar.pkl')
 
-        with from_url('s3://test-dummy-bucket') as s3:
-            assert not s3.exists('base/foo.pkl')
-            assert s3.exists('base/bar.pkl')
+    with from_url('s3://test-bucket') as s3:
+        assert not s3.exists('base/foo.pkl')
+        assert s3.exists('base/bar.pkl')
 
-        with open_url('s3://test-dummy-bucket/base/bar.pkl', 'rb',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as f:
-            assert pickle.load(f) == {'test': 'data'}
+    with open_url('s3://test-bucket/base/bar.pkl', 'rb',
+                  **s3_fixture.aws_kwargs) as f:
+        assert pickle.load(f) == {'test': 'data'}

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -247,3 +247,28 @@ def test_s3_pickle():
                       aws_access_key_id=key,
                       aws_secret_access_key=secret) as f:
             assert pickle.load(f) == {'test': 'data'}
+
+
+@mock_s3
+def test_rename():
+    bucket = "test-dummy-bucket"
+    key = "it's me!deadbeef"
+    secret = "asedf;lkjdf;a'lksjd"
+    with S3(bucket, create_bucket=True):
+        with from_url('s3://test-dummy-bucket/base',
+                      aws_access_key_id=key,
+                      aws_secret_access_key=secret) as s3:
+
+            with s3.open('foo.pkl', 'wb') as fp:
+                pickle.dump({'test': 'data'}, fp)
+
+            s3.rename('foo.pkl', 'bar.pkl')
+
+        with from_url('s3://test-dummy-bucket') as s3:
+            assert not s3.exists('base/foo.pkl')
+            assert s3.exists('base/bar.pkl')
+
+        with open_url('s3://test-dummy-bucket/base/bar.pkl', 'rb',
+                      aws_access_key_id=key,
+                      aws_secret_access_key=secret) as f:
+            assert pickle.load(f) == {'test': 'data'}

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -247,3 +247,16 @@ def test_rename(s3_fixture):
     with open_url('s3://test-bucket/base/bar.pkl', 'rb',
                   **s3_fixture.aws_kwargs) as f:
         assert pickle.load(f) == {'test': 'data'}
+
+
+def test_remove(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
+
+        with pytest.raises(FileNotFoundError) as err:
+            s3.remove('non-existent-object')
+        assert str(err.value) == "No such S3 object: 'non-existent-object'"
+
+        touch(s3, 'foo.data', '0123456789')
+        assert s3.exists('foo.data')
+        s3.remove('foo.data')
+        assert not s3.exists('foo.data')


### PR DESCRIPTION
In the current pfio, `S3.rename` just copies the content into a new file, not removing the original one.

### Fixing `rename`
```python
>>> with pfio.v2.from_url('s3://suzuo/writer/test') as fs:
...     with fs.open('foo.dat', 'wb') as f:
...         f.write(b'hello world')
... 
...     print('ls before', list(fs.list()))
...     fs.rename('foo.dat', 'bar.dat')
...     print('ls after', list(fs.list()))

ls before ['foo.dat']
ls after ['bar.dat', 'foo.dat']
```

This is because that `rename` calls `remove` to delete the source object *with the key normalized*, which is then normalized again inside the `remove`. So `remove` tries to remove the specified key that does not exist instead of the original source one that we actually need to delete.
https://github.com/pfnet/pfio/blob/2.0.1/pfio/v2/s3.py#L523

This PR fixes the unnecessary normalization when calling `remove` in `rename`.

### Fixing `remove`

One of the reasons why the incorrect `rename` behavior is missed would be because `remove` didn't raise anything even if the specified target doesn't actually exist.
This S3 behavior is inconsistent to other filesystems.
Since it seems to be a constraint comes from [boto3](https://github.com/boto/boto3/issues/759) or perhaps [S3 itself](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html), I added an explicit existence check.


### Test refactoring

In addition, since S3 test cases it getting increased, I DRYed fixtures to make each test case a little simpler.

The following conventional test case
```python
@mock_s3
def test_foo():
    bucket = "test-dummy-bucket"
    key = "it's me!deadbeef"
    secret = "asedf;lkjdf;a'lksjd"
    with S3(bucket, create_bucket=True):
        with from_url('s3://test-dummy-bucket/',
                      aws_access_key_id=key,
                      aws_secret_access_key=secret) as s3:
            ...
        with open_url('s3://test-dummy-bucket/xxxx', 'rb'
                      aws_access_key_id=key,
                      aws_secret_access_key=secret) as f:
            ...
```
can be equivalently rewritten as:
```python
def test_foo(s3_fixture):
    with from_url('s3://test-dummy-bucket/', **s3_fixture.aws_kwargs) as s3:
        ...
    with open_url('s3://test-dummy-bucket/xxxx', 'rb', **s2_fixture.aws_kwargs) as f:
        ...
```
