### PR TITLE
Fix import degradation

### DIFF
--- a/pfio/__init__.py
+++ b/pfio/__init__.py
@@ -1,1 +1,3 @@
 import pfio.cache  # NOQA
+import pfio.v2  # NOQA
+from pfio.version import __version__  # NOQA


### PR DESCRIPTION
With pfio==2.0.1, importing `pfio` automatically make `v2` and `__version__` visible.
```python
>>> import pfio
>>> pfio.__version__
'2.0.1'
>>> pfio.v2
<module 'pfio.v2' from '/home/xxx/xxx/pfio/pfio/v2/__init__.py'>
```

But in 2.1.0 this won't work.

```python
>>> import pfio
>>> pfio.__version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pfio' has no attribute '__version__'
>>> pfio.version.__version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pfio' has no attribute 'version'
>>> import pfio.version
>>> pfio.version.__version__
'2.1.0'
>>> pfio.v2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pfio' has no attribute 'v2'
>>> import pfio.v2
>>> pfio.v2
<module 'pfio.v2' from '/home/xxx/xxx/pfio/pfio/v2/__init__.py'>
```

Related commit.
https://github.com/pfnet/pfio/pull/250/files