### PR TITLE
Improve readlines performance

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -380,14 +380,21 @@ class S3(FS):
         path = _normalize_key(path)
         if 'r' in mode:
             obj = _ObjectReader(self.client, self.bucket, path, mode, kwargs)
+
+            bs = self.buffering
+            if bs < 0:
+                bs = min(obj.content_length, DEFAULT_MAX_BUFFER_SIZE)
+
             if 'b' in mode:
                 if self.buffering:
-                    bs = self.buffering
-                    if bs < 0:
-                        bs = min(obj.content_length, DEFAULT_MAX_BUFFER_SIZE)
                     obj = io.BufferedReader(obj, buffer_size=bs)
             else:
                 obj = io.TextIOWrapper(obj)
+                if self.buffering:
+                    # This is undocumented property; but resident at
+                    # least since 2009 (the merge of io-c branch).
+                    # We'll use it until the day of removal.
+                    obj._CHUNK_SIZE = bs
 
         elif 'w' in mode:
             obj = _ObjectWriter(self.client, self.bucket, path, mode,


### PR DESCRIPTION
The default buffer size of io.TextIOWrapper is just 8K. If the underlying FileObject is an accesser to remote storage system, the latency may affect overall performance of reading lines of a fairly large text file like this:
```python
with pfio.v2.open_url("s3://bucket/key", "r") as f:
    print(len(f.readlines()))
```

Python's io.TextIOWrapper has a property `_CHUNK_SIZE` at least since 2009 ( see https://github.com/python/cpython/commit/4fa88fa0ba35e25ad9be66ebbdaba9aca553dc8b ). Although this is undocumented, I would like to hack it and improve performance. To monitor and guarantee its existence, added some explicit tests.