### PR TITLE
Use XDG standard for cache path

### DIFF
--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -10,10 +10,22 @@ from struct import calcsize, pack, unpack
 
 from pfio import cache
 
+# Deprecated, but leaving for backward compatibility just in case any
+# system directly using this value
 _DEFAULT_CACHE_PATH = os.path.join(
     os.getenv('HOME'), ".pfio", "cache")
 
 _FORCE_LOCAL = True
+
+
+def _default_cache_path():
+    basedir = os.getenv('XDG_CACHE_HOME')
+
+    if not basedir:
+        basedir = os.path.join(os.getenv('HOME'), ".cache")
+
+    cachedir = os.path.join(basedir, "pfio")
+    return cachedir
 
 
 class LockContext:
@@ -103,7 +115,8 @@ class FileCache(cache.Cache):
     '''Cache system with local filesystem
 
     Stores cache data in a local temporary file created in
-    ``~/.pfio/cache`` by default. Cache data is
+    ``$XDG_CACHE_HOME/pfio`` by default. If it is unset,
+    ``$HOME/.cache/pfio`` will be the cache destination. Cache data is
     automatically deleted after the object is collected. When this
     object is not correctly closed, (e.g., the process killed by
     SIGTERM), the cache remains after the death of process.
@@ -161,7 +174,7 @@ class FileCache(cache.Cache):
             self.lock = DummyLock()
 
         if dir is None:
-            self.dir = _DEFAULT_CACHE_PATH
+            self.dir = _default_cache_path()
         else:
             self.dir = dir
         os.makedirs(self.dir, exist_ok=True)

--- a/pfio/cache/mmap_file_cache.py
+++ b/pfio/cache/mmap_file_cache.py
@@ -5,6 +5,7 @@ import pickle
 from struct import calcsize, unpack
 
 from pfio import cache
+from pfio.cache.file_cache import _default_cache_path
 
 
 class ReadOnlyFileCache(cache.Cache):
@@ -33,7 +34,7 @@ class ReadOnlyFileCache(cache.Cache):
             raise ValueError("length has to be between 0 and 2^64")
 
         if dir is None:
-            self.dir = cache.FileCache._DEFAULT_CACHE_PATH
+            self.dir = _default_cache_path()
         else:
             self.dir = dir
         cache.file_cache._check_local(self.dir)

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -8,7 +8,7 @@ import warnings
 from struct import calcsize, pack, unpack
 
 from pfio import cache
-from pfio.cache.file_cache import _DEFAULT_CACHE_PATH, _check_local
+from pfio.cache.file_cache import _check_local, _default_cache_path
 
 
 class _NoOpenNamedTemporaryFile(object):
@@ -156,7 +156,7 @@ class MultiprocessFileCache(cache.Cache):
         self.cache_size_limit = cache_size_limit
 
         if dir is None:
-            self.dir = _DEFAULT_CACHE_PATH
+            self.dir = _default_cache_path()
         else:
             self.dir = dir
         os.makedirs(self.dir, exist_ok=True)

--- a/tests/cache_tests/test_cache.py
+++ b/tests/cache_tests/test_cache.py
@@ -367,3 +367,24 @@ def test_preload_error_not_found(test_class):
         assert cache.preload('preserved') is False
 
         cache.close()
+
+
+@pytest.mark.parametrize("test_class", [FileCache, MultiprocessFileCache])
+def test_default_cache_path(test_class):
+    orig = os.getenv('XDG_CACHE_HOME')
+
+    os.environ['XDG_CACHE_HOME'] = "/tmp/pfio-cache"
+
+    try:
+        with test_class(16) as c:
+            assert "/tmp/pfio-cache/pfio" == c.dir
+
+        os.environ['XDG_CACHE_HOME'] = ''
+
+        with test_class(16) as c:
+            path = os.path.join(os.getenv('HOME'), '.cache', 'pfio')
+            assert path == c.dir
+
+    finally:
+        if orig is not None:
+            os.environ['XDG_CACHE_HOME'] = orig


### PR DESCRIPTION
Addresses #261 . 

The XDG standard says

> $XDG_CACHE_HOME defines the base directory relative to which user-specific non-essential data files should be stored. If $XDG_CACHE_HOME is either not set or empty, a default equal to $HOME/.cache should be used.