### PR TITLE
Introduce reset_on_fork argument

### DIFF
--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -322,8 +322,8 @@ def from_url(url: str, **kwargs) -> 'FS':
     built from it accordingly. The URL path is supposed to
     be a directory for file systems or a path prefix for S3.
 
-    .. warning:: When opening an ``hdfs://...`` URL, be sure
-        about forking context. See: :class:`Hdfs` .
+    .. warning:: When opening an ``hdfs://...`` URL, be sure about
+        forking context. See: :class:`Hdfs` for discussion.
 
     Arguments:
         url (str): A URL string compliant with RFC 1738.
@@ -335,7 +335,7 @@ def from_url(url: str, **kwargs) -> 'FS':
         create (bool): Create the specified path doesn't exist.
 
         reset_on_fork (bool): Reset stateful objects (e.g. connection
-            to the remote system) before fork.
+            to the remote system) after fork.
 
     .. note:: Some FS resouces won't be closed when using this
         functionality.

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -322,6 +322,9 @@ def from_url(url: str, **kwargs) -> 'FS':
     built from it accordingly. The URL path is supposed to
     be a directory for file systems or a path prefix for S3.
 
+    .. warning:: When opening an ``hdfs://...`` URL, be sure
+        about forking context. See: :class:`Hdfs` .
+
     Arguments:
         url (str): A URL string compliant with RFC 1738.
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -9,6 +9,10 @@ from types import TracebackType
 from typing import Any, Callable, Iterator, Optional, Type
 from urllib.parse import urlparse
 
+from deprecation import deprecated
+
+from pfio.version import __version__  # NOQA
+
 
 class FileStat(abc.ABC):
     """Detailed file or directory information abstraction
@@ -82,8 +86,9 @@ class FS(abc.ABC):
 
     _cwd = ''
 
-    def __init__(self):
+    def __init__(self, reset_on_fork=False):
         self.pid = os.getpid()
+        self.reset_on_fork = reset_on_fork
 
     @property
     def cwd(self):
@@ -124,11 +129,22 @@ class FS(abc.ABC):
         sub = copy.copy(self)
 
         sub._cwd = os.path.join(self.cwd, rel_path)
+        sub._reset()
         return sub
 
     def _checkfork(self):
-        if self.is_forked:
+        if not self.is_forked:
+            return
+
+        # Forked!
+        if self.reset_on_fork:
+            self._reset()
+        else:
             raise ForkedError()
+
+    @abstractmethod
+    def _reset(self):
+        raise NotImplementedError()
 
     @property
     def is_forked(self):
@@ -315,8 +331,14 @@ def from_url(url: str, **kwargs) -> 'FS':
 
         create (bool): Create the specified path doesn't exist.
 
+        reset_on_fork (bool): Reset stateful objects (e.g. connection
+            to the remote system) before fork.
+
     .. note:: Some FS resouces won't be closed when using this
         functionality.
+
+    .. note:: Pickling the FS object may or may not work correctly
+        depending on the implementation.
 
     '''
     parsed = urlparse(url)
@@ -381,6 +403,8 @@ def _from_scheme(scheme, dirname, kwargs, bucket=None):
     return fs
 
 
+@deprecated(deprecated_in='2.2.0', removed_in='2.3.0',
+            current_version=__version__)
 def lazify(init_func, lazy_init=True, recreate_on_fork=True) -> "FS":
     '''Make FS init lazy and recreate on fork
 

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -215,7 +215,7 @@ class Hdfs(FS):
         self._fs = _create_fs()
 
     def __getstate__(self):
-        state = self.__dict__
+        state = self.__dict__.copy()
         state['_fs'] = None
         return state
 

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -181,10 +181,11 @@ class Hdfs(FS):
     command is not available from ``$PATH``.
 
 
-    .. warning:: In principle, ``reset_on_fork=False`` is recommended
-          for HDFS in order not to shoot yourself in the foot;
-          multiprocessing with a JVM instance that has different
-          memory model may cause unexpected behavior. If you do *need*
+    .. warning:: It is strongly discouraged to use :class:`Hdfs` under
+          multiprocessing. Setting ``reset_on_fork=False`` is
+          recommended for HDFS in order not to shoot yourself in the
+          foot. Forking a JVM instance that has a different memory
+          model may cause unexpected behavior. If you do *need*
           forking, for example, PyTorch DataLoader with multiple
           workers for performance, it is strongly recommended not to
           instantiate :class:`Hdfs` before forking. Details are

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -181,14 +181,16 @@ class Hdfs(FS):
     command is not available from ``$PATH``.
 
 
-    .. warning:: Although ``reset_on_fork=False`` is recommended for
-          HDFS, some applications such as PyTorch DataLoader need
-          forking for performance. In that case, it is strongly
-          recommended not to instantiate :class:`Hdfs` *before*
-          forking. Details are described in PFIO issue #123.
-          Simple workaround is to set multiprocessing start
-          method as ``'forkserver'`` and start the very first
-          child process before everything.
+    .. warning:: In principle, ``reset_on_fork=False`` is recommended
+          for HDFS in order not to shoot yourself in the foot;
+          multiprocessing with a JVM instance that has different
+          memory model may cause unexpected behavior. If you do *need*
+          forking, for example, PyTorch DataLoader with multiple
+          workers for performance, it is strongly recommended not to
+          instantiate :class:`Hdfs` before forking. Details are
+          described in PFIO issue #123.  Simple workaround is to set
+          multiprocessing start method as ``'forkserver'`` and start
+          the very first child process before everything.
 
           .. code-block::
 

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -189,8 +189,8 @@ class Hdfs(FS):
           keytab will be used to update the Kerberos ticket.
     '''
 
-    def __init__(self, cwd=None, create=False, **_):
-        super().__init__()
+    def __init__(self, cwd=None, create=False, reset_on_fork=False, **_):
+        super().__init__(reset_on_fork=reset_on_fork)
         self._fs = _create_fs()
         assert self._fs is not None
         self.username = self._get_principal_name()
@@ -210,6 +210,17 @@ class Hdfs(FS):
                 self.makedirs('', exist_ok=True)
             else:
                 raise ValueError('{} must be a directory'.format(self.cwd))
+
+    def _reset(self):
+        self._fs = _create_fs()
+
+    def __getstate__(self):
+        state = self.__dict__
+        state['_fs'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
 
     def _get_principal_name(self):
         # get the default principal name from `klist` cache

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -5,8 +5,8 @@ import multiprocessing
 import os
 import re
 import subprocess
-from xml.etree import ElementTree
 import warnings
+from xml.etree import ElementTree
 
 import pyarrow
 from pyarrow.fs import FileSelector, FileType, HadoopFileSystem

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -184,8 +184,8 @@ class Hdfs(FS):
     .. warning:: It is strongly discouraged to use :class:`Hdfs` under
           multiprocessing. Setting ``reset_on_fork=False`` is
           recommended for HDFS in order not to shoot yourself in the
-          foot. Forking a JVM instance that has a different memory
-          model may cause unexpected behavior. If you do *need*
+          foot, because forking a JVM instance that has a different
+          memory model may cause unexpected behavior. If you do *need*
           forking, for example, PyTorch DataLoader with multiple
           workers for performance, it is strongly recommended not to
           instantiate :class:`Hdfs` before forking. Details are

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -43,8 +43,8 @@ class LocalFileStat(FileStat):
 
 
 class Local(FS):
-    def __init__(self, cwd=None, create=False, **_):
-        super().__init__()
+    def __init__(self, cwd=None, create=False, reset_on_fork=False, **_):
+        super().__init__(reset_on_fork=reset_on_fork)
 
         if cwd is None:
             self._cwd = ''
@@ -65,6 +65,9 @@ class Local(FS):
             return self._cwd
 
         return os.getcwd()
+
+    def _reset(self):
+        pass
 
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -374,7 +374,7 @@ class S3(FS):
                 raise e
 
     def __getstate__(self):
-        state = self.__dict__
+        state = self.__dict__.copy()
         state['client'] = None
         return state
 

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -307,9 +307,11 @@ class S3(FS):
                  mpu_chunksize=32*1024*1024,
                  buffering=-1,
                  create=False,
+                 reset_on_fork=False,
                  **_):
-        super().__init__()
+        super().__init__(reset_on_fork=reset_on_fork)
         self.bucket = bucket
+        self.create_bucket = create_bucket
         if prefix is not None:
             self.cwd = prefix
         else:
@@ -352,17 +354,32 @@ class S3(FS):
         if self.endpoint is not None:
             kwargs['endpoint_url'] = self.endpoint
 
+        self.kwargs = kwargs
+        self._connect()
+
+    def _reset(self):
+        self._connect()
+
+    def _connect(self):
         # print('boto3.client options:', kwargs)
-        self.client = boto3.client('s3', **kwargs)
+        self.client = boto3.client('s3', **self.kwargs)
 
         try:
-            self.client.head_bucket(Bucket=bucket)
+            self.client.head_bucket(Bucket=self.bucket)
         except ClientError as e:
-            if e.response['Error']['Code'] == '404' and create_bucket:
-                res = self.client.create_bucket(Bucket=bucket)
-                print("Bucket", bucket, "created:", res)
+            if e.response['Error']['Code'] == '404' and self.create_bucket:
+                res = self.client.create_bucket(Bucket=self.bucket)
+                print("Bucket", self.bucket, "created:", res)
             else:
                 raise e
+
+    def __getstate__(self):
+        state = self.__dict__
+        state['client'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
 
     def open(self, path, mode='r', **kwargs):
         '''Opens an object accessor for read or write


### PR DESCRIPTION
To address https://github.com/pfnet/pfio/issues/260 , a new argument `reset_on_fork` is introduced to each FS object constructor. If it is turned on, internal method `_check_fork()` calls a newly introduced abstract method `_reset(self)` . This abstraction enables transparent forking in any situation - be it PyTorch DataLoader or multiprocessing, or "forkserver" enabled.

Classes `S3` and `Hdfs` now do not pickle their internal unpickable, e.g. boto connection or Hdfs connection. If they're forked, they're forced to reset the connection.

It also worked well with PyTorch DataLoader like this:

```python
import time
import os
import multiprocessing

import torch
from pfio.v2 import from_url

class Dataset:
    def __init__(self):
        self.s3 = from_url('s3://bucket/', reset_on_fork=True)

    def __len__(self):
        return 1600

    def __getitem__(self, i):
        with self.s3.open('sl.c', 'rb') as fp:
            return fp.read()

multiprocessing.set_start_method('forkserver', force=True)
#p = multiprocessing.Process()
#p.start()
#p.join()

def main():
    ds = Dataset()
    loader = torch.utils.data.DataLoader(ds, batch_size=8, num_workers=2)
    it = iter(loader)
    data = next(it)
    print(len(data))
    data = next(it)
    print(len(data))
    data = next(it)
    print(type(data))

if __name__ == '__main__':
    main()
```

```sh
$ python dataloader_test.py
8
8
<class 'list'>
```
Note: this change deprecates `pfio.v2.lazify()` .