### PR TITLE
Fix Cache for numpy

### DIFF
--- a/pfio/cache/__init__.py
+++ b/pfio/cache/__init__.py
@@ -50,7 +50,7 @@ class Cache(abc.ABC):
 
         '''
         data = self.get(i)
-        if not data:
+        if data is None:
             data = backend_get(i)
             self.put(i, data)
         return data

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     package_data={'pfio': package_data},
     extras_require={
-        'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto'],
+        'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto', 'numpy'],
         # When updating doc deps, docs/requirements.txt should be updated too
         'doc': ['sphinx', 'sphinx_rtd_theme'],
         'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],

--- a/tests/cache_tests/test_cache.py
+++ b/tests/cache_tests/test_cache.py
@@ -83,6 +83,7 @@ def test_cache_numpy(test_class, mt_safe, do_shuffle):
     length = l = 1024
     cache = make_cache(test_class, mt_safe, True, l)
     arr_list = np.random.rand(l, 3, 4)
+
     def getter(i):
         return arr_list[i]
     if do_shuffle:

--- a/tests/cache_tests/test_cache.py
+++ b/tests/cache_tests/test_cache.py
@@ -6,6 +6,7 @@ import tempfile
 
 import numpy as np
 import pytest
+
 from pfio.cache import FileCache, MultiprocessFileCache, NaiveCache
 
 


### PR DESCRIPTION
When we use `Cache.get_and_cache()` for `numpy.ndarray`, we get the following error:
```
 ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This PR fixes the above issue.