### PR TITLE
Fix `BufferedReader` error caused by opening an empty file in S3 in "rb" mode

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -403,7 +403,7 @@ class S3(FS):
                 bs = min(obj.content_length, DEFAULT_MAX_BUFFER_SIZE)
 
             if 'b' in mode:
-                if self.buffering:
+                if self.buffering and bs != 0:
                     obj = io.BufferedReader(obj, buffer_size=bs)
             else:
                 obj = io.TextIOWrapper(obj)

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -112,6 +112,19 @@ def test_s3_read(s3_fixture, buffering, reader_type):
             assert not fp.closed
 
 
+def test_empty_file(s3_fixture):
+    with from_url('s3://test-bucket/base',
+                  **s3_fixture.aws_kwargs) as s3:
+
+        # Create an empty file
+        with s3.open('foo.dat', 'wb'):
+            pass
+
+        # It should be able to read it without error
+        with s3.open('foo.dat', 'rb') as f:
+            assert len(f.read()) == 0
+
+
 def test_s3_fork(s3_fixture):
     with from_url('s3://test-bucket/base',
                   **s3_fixture.aws_kwargs) as s3:


### PR DESCRIPTION
Fixes #269 