### PR TITLE
Sparse file local cache

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -72,6 +72,14 @@ but several methods are not yet implemented.
 .. autoclass:: pfio.v2.pathlib.Path
    :members:
 
+Sparse File Cache
+-----------------
+
+.. autoclass:: pfio.cache.SparseFileCache
+   :members:
+
+.. autoclass:: pfio.cache.sparse_file.CachedWrapper
+   :members:
 
 
 Cache API

--- a/pfio/cache/__init__.py
+++ b/pfio/cache/__init__.py
@@ -60,5 +60,4 @@ from pfio.cache.file_cache import FileCache  # NOQA
 from pfio.cache.mmap_file_cache import ReadOnlyFileCache  # NOQA
 from pfio.cache.multiprocess_file_cache import MultiprocessFileCache  # NOQA
 from pfio.cache.naive import NaiveCache  # NOQA
-
-from pfio.cache.sparse_file import CachedWrapper as SparseFileCache # NOQA
+from pfio.cache.sparse_file import CachedWrapper as SparseFileCache  # NOQA

--- a/pfio/cache/__init__.py
+++ b/pfio/cache/__init__.py
@@ -60,3 +60,5 @@ from pfio.cache.file_cache import FileCache  # NOQA
 from pfio.cache.mmap_file_cache import ReadOnlyFileCache  # NOQA
 from pfio.cache.multiprocess_file_cache import MultiprocessFileCache  # NOQA
 from pfio.cache.naive import NaiveCache  # NOQA
+
+from pfio.cache.sparse_file import CachedWrapper as SparseFileCache # NOQA

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -266,7 +266,9 @@ class CachedWrapper(_CachedWrapper):
         self.ranges = [_Range(i * self.pagesize, self.pagesize, cached=False)
                        for i in range(pagecount)]
 
-        self.ranges.append(_Range(pagecount*self.pagesize, size % self.pagesize, cached=False))
+        remain = size % self.pagesize
+        if remain > 0:
+            self.ranges.append(_Range(pagecount*self.pagesize, remain, cached=False))
 
     def read(self, size=-1) -> bytes:
         if self._closed:

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -6,12 +6,11 @@ Of course, it's read only
 
 import io
 import os
-import tempfile
 import shutil
-
-from typing import Optional
-from types import TracebackType
+import tempfile
 from dataclasses import dataclass
+from types import TracebackType
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -42,6 +41,7 @@ class CachedWrapper:
 
     TODO: add document here
     '''
+
     def __init__(self, fileobj, size, cachedir=None):
         self.fileobj = fileobj
         self.cachedir = cachedir

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -184,7 +184,7 @@ class CachedWrapper:
         self.pos %= self.size
         if self.pos != self.fileobj.tell():
             self.fileobj.seek(self.pos, io.SEEK_SET)
-        return buf
+        return bytes(buf)
 
     def readline(self):
         raise NotImplementedError()

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -274,12 +274,14 @@ class CachedWrapper(_CachedWrapper):
         if self._closed:
             raise RuntimeError("closed")
 
-        if size < 0:
+        if size < 0 or (self.size - self.pos < size):
             size = self.size - self.pos
 
         start = self.pos // self.pagesize
         end = (self.pos + size) // self.pagesize
+        # print((self.pos, self.pos+size), "=>", list(range(start, end+1)), "size", self.size)
         for i in range(start, end + 1):
+            # print('range=', i, "total=", len(self.ranges))
             r = self.ranges[i]
             
             if not r.cached:

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -42,7 +42,7 @@ class CachedWrapper:
     TODO: add document here
     '''
 
-    def __init__(self, fileobj, size, cachedir=None):
+    def __init__(self, fileobj, size, cachedir=None, close_on_close=False):
         self.fileobj = fileobj
         self.cachedir = cachedir
         self.size = size
@@ -61,11 +61,14 @@ class CachedWrapper:
         self.ranges = [_Range(0, size)]
         self._closed = False
         self._frozen = False
+        self.close_on_close = close_on_close
 
     def close(self):
         if not self._closed:
             self._closed = True
             self.cachefp.close()
+            if self.close_on_close:
+                self.fileobj.close()
 
     def preserve(self, dest):
         # Hard link and save them

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -1,0 +1,249 @@
+'''
+A cache system for remote file system that stores cache as mmap'ed file locally
+
+Of course, it's read only
+'''
+
+import io
+import os
+import tempfile
+import shutil
+
+from typing import Optional
+from types import TracebackType
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _Range:
+    start: int
+    length: int
+    cached: bool = False
+
+    def overlap(self, rhs) -> bool:
+        return (self.start - rhs.right) * (self.right - rhs.start) < 0
+
+    @property
+    def right(self):
+        return self.start + self.length
+
+    def includes(self, rhs) -> bool:
+        return (self.start <= rhs.start) and (rhs.right <= self.right)
+
+    def merge(self, rhs):
+        assert self.overlap(rhs)
+        assert self.cached == rhs.cached
+        return _Range(min(self.start, rhs.start), max(self.right, rhs.right),
+                      cached=self.cached)
+
+
+class CachedWrapper:
+    '''A transparent local cache for remote files
+
+    TODO: add document here
+    '''
+    def __init__(self, fileobj, size, cachedir=None):
+        self.fileobj = fileobj
+        self.cachedir = cachedir
+        self.size = size
+        assert size > 0
+        if cachedir is None:
+            basedir = os.getenv('XDG_CACHE_HOME')
+            if basedir is None:
+                basedir = os.path.join(os.getenv('HOME'), ".cache")
+            self.cachedir = os.path.join(basedir, "pfio")
+        os.makedirs(self.cachedir, exist_ok=True)
+        self.cachefp = tempfile.NamedTemporaryFile(delete=True,
+                                                   dir=self.cachedir)
+        # self.cachefp = open('cache.file', 'rwb')
+        # self.cachefp = os.open('cache.file', os.O_RDWR|os.O_TRUNC)
+        # TODO: make this tree if the size gets too long for O(n) scan
+        self.ranges = [_Range(0, size)]
+        self._closed = False
+        self._frozen = False
+
+    def close(self):
+        if not self._closed:
+            self._closed = True
+            self.cachefp.close()
+
+    def preserve(self, dest):
+        # Hard link and save them
+        try:
+            os.link(self.cachefp.name, dest)
+            self.cachefp.close()
+        except OSError:
+            # TODO: check errno to make sure handling the
+            # 'different-drive' error.
+            shutil.copyfile(self.cachefp.name, dest)
+
+        self.cachefp = open(dest, 'rb')
+        self._frozen = True
+
+    def _get_range(self, r) -> (bytearray, _Range):
+        # print('get range:', r)
+        if r.cached:
+            return os.pread(self.cachefp.fileno(), r.length, r.start), r
+
+        assert not self._frozen
+        self.fileobj.seek(r.start, io.SEEK_SET)
+        data = self.fileobj.read(r.length)
+        written = os.pwrite(self.cachefp.fileno(), data, r.start)
+        if written < 0:
+            raise RuntimeError("bad file descriptor")
+        # print(written, "/", r.length, "bytes written at", r.start)
+        return data, _Range(r.start, r.length, True)
+
+    def _read(self, size):
+        new_ranges = []
+        streak = []
+        for data, r in self._read2(size):
+            if r.length > 0:
+                if r.cached:
+                    streak.append(r)
+                else:
+                    if streak:
+                        start = streak[0].start
+                        length = sum(s.length for s in streak)
+                        new_ranges.append(_Range(start, length, cached=True))
+                        streak = []
+                    new_ranges.append(r)
+
+            if data is not None:
+                yield data
+
+        if streak:
+            start = streak[0].start
+            length = sum(s.length for s in streak)
+            new_ranges.append(_Range(start, length, cached=True))
+
+        self.ranges = new_ranges
+
+    def _read2(self, size):
+
+        r0 = _Range(self.pos, size)
+        # print("read =>", r0)
+        for r1 in self.ranges:
+            if not r1.overlap(r0):
+                yield None, r1
+                continue
+
+            # [r0 [ ... r1] never happens as the first r1 always starts with 0
+            assert r1.start <= r0.start
+
+            # [r1 [ r0 ] ] r1 cached; prevent unnecessary area split
+            if r1.includes(r0) and r1.cached:
+                data = os.pread(self.cachefp.fileno(), r0.length, r0.start)
+                # print(r1, 'includes', r0, 'len(r0)?=', len(data))
+                yield data, r1
+                continue
+
+            yield None, _Range(r1.start, r0.start - r1.start, r1.cached)
+
+            # [ r1 [ r0 ] ]
+            if r0.right < r1.right:
+                yield self._get_range(_Range(r0.start, r0.length, r1.cached))
+                # print('[ r1 [ r0 ] ]', r, len(data))
+                yield None, _Range(r0.right, r1.right - r0.right, r1.cached)
+                continue
+
+            # [ r1 [ ] r0 ]
+            yield self._get_range(_Range(r0.start, r1.right - r0.start,
+                                         r1.cached))
+            # print('[ r1 [ ] r0 ]', r, len(data))
+
+            r0 = _Range(r1.right, r0.right - r1.right)
+
+    def _read_all_cache(self):
+        for r in self.ranges:
+            if r.cached:
+                data = os.pread(self.cachefp.fileno(), r.length, r.start)
+                # print(r1, 'includes', r0, 'len(r0)?=', len(data))
+                yield data, r
+            else:
+                yield None, r
+
+    def read(self, size=-1) -> bytes:
+        if self._closed:
+            raise RuntimeError("closed")
+
+        if size < 0:
+            size = self.size - self.pos
+
+        buf = bytearray(size)
+        offset = 0
+        # TODO: unnecessary copy; optimize with os.readv?
+        for data in self._read(size):
+            buf[offset:offset+len(data)] = data
+            offset += len(data)
+
+        self.pos += len(buf)
+        self.pos %= self.size
+        if self.pos != self.fileobj.tell():
+            self.fileobj.seek(self.pos, io.SEEK_SET)
+        return buf
+
+    def readline(self):
+        raise NotImplementedError()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type: Optional[BaseException],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> bool:
+        self.close()
+
+    def flush(self):
+        pass
+
+    @property
+    def closed(self):
+        return self._closed
+
+    def isatty(self):
+        return False
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def tell(self):
+        return self.pos
+
+    def truncate(self, size=None):
+        raise io.UnsupportedOperation('truncate')
+
+    def seek(self, pos, whence=io.SEEK_SET):
+        # print(dir(self.fileobj))
+        if whence in [0, io.SEEK_SET]:
+            if pos < 0:
+                raise OSError(22, "[Errno 22] Invalid argument")
+        elif whence in [1, io.SEEK_CUR]:
+            pos += self.pos
+        elif whence in [2, io.SEEK_END]:
+            pos += self.size
+        else:
+            raise ValueError('Wrong whence value: {}'.format(whence))
+
+        if pos < 0:
+            raise OSError(22, "[Errno 22] Invalid argument")
+        self.pos = pos
+        self.fileobj.seek(self.pos, io.SEEK_SET)
+        return self.pos
+
+    def writable(self):
+        return False
+
+    def write(self, data):
+        raise io.UnsupportedOperation('not writable')
+
+    def readall(self):
+        return self.read(-1)
+
+    def readinto(self, b):
+        buf = self.read(len(b))
+        b[:len(buf)] = buf
+        return len(buf)

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -390,6 +390,15 @@ class S3(FS):
 
         .. note:: Multi-part upload is not yet available.
 
+        Arguments:
+            path (str): relative path from basedir
+
+            mode (str): open mode
+
+            local_cache (bool): use sparse file cache for opening ZIP file
+
+            local_cachedir (dir): local path to store sparse file cache
+
         '''
         self._checkfork()
         if 'a' in mode:

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -4,9 +4,9 @@ import os
 import zipfile
 from datetime import datetime
 
-from .fs import FS, FileStat
 from pfio.cache.sparse_file import CachedWrapper
 
+from .fs import FS, FileStat
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())

--- a/tests/cache_tests/test_sparse_file.py
+++ b/tests/cache_tests/test_sparse_file.py
@@ -5,7 +5,6 @@ import tempfile
 import zipfile
 
 from pfio.cache.sparse_file import CachedWrapper
-
 from pfio.testing import ZipForTest
 
 

--- a/tests/cache_tests/test_sparse_file.py
+++ b/tests/cache_tests/test_sparse_file.py
@@ -4,7 +4,7 @@ import random
 import tempfile
 import zipfile
 
-from pfio.cache.sparse_file import CachedWrapper
+from pfio.cache import SparseFileCache
 from pfio.testing import ZipForTest
 
 
@@ -19,7 +19,7 @@ def test_sparse_file_cache():
         size = stat.st_size
         with open(filepath, 'rb') as xfp:
 
-            with CachedWrapper(xfp, size) as fp:
+            with SparseFileCache(xfp, size) as fp:
 
                 fp.seek(26)
                 data = fp.read(17)
@@ -49,7 +49,7 @@ def test_sparse_file_cache2():
         size = stat.st_size
         with open(filepath, 'rb') as xfp, open(filepath, 'rb') as yfp:
 
-            with CachedWrapper(xfp, size) as fp:
+            with SparseFileCache(xfp, size) as fp:
 
                 fp.seek(26)
                 # print('seek done:', fp.pos, xfp.tell())
@@ -94,7 +94,7 @@ def test_sparse_cache_zip():
 
         size = stat.st_size
         with open(filepath, 'rb') as xfp:
-            with CachedWrapper(xfp, size) as cfp:
+            with SparseFileCache(xfp, size) as cfp:
                 with zipfile.ZipFile(cfp, 'r') as zfp:
 
                     assert zfp.testzip() is None

--- a/tests/cache_tests/test_sparse_file.py
+++ b/tests/cache_tests/test_sparse_file.py
@@ -1,0 +1,107 @@
+import filecmp
+import os
+import random
+import tempfile
+import zipfile
+
+from pfio.cache.sparse_file import CachedWrapper
+
+from pfio.testing import ZipForTest
+
+
+def test_sparse_file_cache():
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        filepath = os.path.join(tempdir, "test.zip")
+        _ = ZipForTest(filepath)
+
+        stat = os.stat(filepath)
+
+        size = stat.st_size
+        with open(filepath, 'rb') as xfp:
+
+            with CachedWrapper(xfp, size) as fp:
+
+                fp.seek(26)
+                data = fp.read(17)
+
+                w = 17
+                for _ in range(100):
+                    offset = random.randint(0, size-w)
+                    fp.seek(offset)
+                    data = fp.read(w)
+                    # print("ranges:", len(fp.ranges))
+                    # print(w, len(data))
+                    assert w == len(data)
+
+                fp.seek(0)
+
+
+def test_sparse_file_cache2():
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        filepath = os.path.join(tempdir, "test.zip")
+        _ = ZipForTest(filepath)
+
+        stat = os.stat(filepath)
+
+        preserve = os.path.join(tempdir, "cache.file")
+
+        size = stat.st_size
+        with open(filepath, 'rb') as xfp, open(filepath, 'rb') as yfp:
+
+            with CachedWrapper(xfp, size) as fp:
+
+                fp.seek(26)
+                # print('seek done:', fp.pos, xfp.tell())
+                data = fp.read(17)
+                # print(len(data))
+
+                w = 17
+                for _ in range(100):
+                    offset = random.randint(0, size-w)
+                    fp.seek(offset)
+                    assert fp.pos == xfp.tell()
+                    buf = fp.read(w)
+                    # print("><", offset, offset+w, fp.pos, xfp.tell())
+                    assert w == len(buf)
+                    # print("ranges:", len(fp.ranges))
+                    # print(w, len(data))
+
+                    for d, r in fp._read_all_cache():
+                        # print(r)
+                        cache = os.pread(yfp.fileno(), r.length, r.start)
+                        if r.cached:
+                            assert cache == d
+
+                fp.seek(26)
+                # print("><", fp.pos, xfp.tell())
+                data2 = fp.read(17)
+                assert data == data2
+                # print("lst read:", len(fp.read(size)))
+
+                fp.preserve(preserve)
+
+        filecmp.cmp(filepath, preserve)
+
+
+def test_sparse_cache_zip():
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        filepath = os.path.join(tempdir, "test.zip")
+        z = ZipForTest(filepath)
+
+        stat = os.stat(filepath)
+
+        size = stat.st_size
+        with open(filepath, 'rb') as xfp:
+            with CachedWrapper(xfp, size) as cfp:
+                with zipfile.ZipFile(cfp, 'r') as zfp:
+
+                    assert zfp.testzip() is None
+                    assert 2 == len(zfp.namelist())
+                    with zfp.open("file", 'r') as fp:
+                        assert z.content("file") == fp.read()
+
+                    with zfp.open("dir/f", "r") as fp:
+                        assert b'bar' == fp.read()

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -37,6 +37,9 @@ def test_s3_zip(local_cache):
             assert not isinstance(z.fileobj, io.BufferedReader)
             if not local_cache:
                 assert isinstance(z.fileobj, pfio.v2.s3._ObjectReader)
+            else:
+                assert isinstance(z.fileobj,
+                                  pfio.cache.sparse_file.CachedWrapper)
 
             assert zipfile.is_zipfile(z.fileobj)
             with z.open('file', 'rb') as fp:

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -31,10 +31,18 @@ def test_s3_zip(local_cache):
                 assert zipfile.is_zipfile(fp)
 
         with from_url('s3://{}/test.zip'.format(bucket),
+                      local_cache=local_cache) as z:
+            assert isinstance(z, Zip)
+            assert isinstance(z.fileobj, io.BufferedReader)
+
+            assert zipfile.is_zipfile(z.fileobj)
+            with z.open('file', 'rb') as fp:
+                assert zft.content('file') == fp.read()
+
+        with from_url('s3://{}/test.zip'.format(bucket),
                       buffering=0, local_cache=local_cache) as z:
             assert isinstance(z, Zip)
             assert 'buffering' in z.kwargs
-            assert not isinstance(z.fileobj, io.BufferedReader)
             if not local_cache:
                 assert isinstance(z.fileobj, pfio.v2.s3._ObjectReader)
             else:

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -872,6 +872,9 @@ def test_is_zipfile():
     with tempfile.TemporaryDirectory() as tmpdir:
         zipfilename = os.path.join(tmpdir, 'test.zip')
         _ = ZipForTest(zipfilename)
+
+        assert zipfile.is_zipfile(zipfilename)
+
         with local as fs:
             with fs.open(zipfilename, 'rb') as fp:
                 assert zipfile.is_zipfile(fp)


### PR DESCRIPTION
With adding `local_cache=True` keyword to opening a zip FS e.g. using `from_url()` , a local cache file is created in a path (by default, `~/.cache/pfio/` ). The cache file is a named temporary file, but potentially, it can easily be persisted locally. It costs the local disk space, but the amount is just as same as the total amount of data transferred over the network to the client.

This will be a major step toward working around #271, as well as improving latency on reading a file from remote file system such as S3.

You can see the difference of space consumed like this:
```
$ ls -lh  ~/.cache/pfio/tmpjwvpycrg
-rw------- 1 kota kota 155G Jun  6 12:29 /home/kota/.cache/pfio/tmpjwvpycrg
$ du -h  ~/.cache/pfio/tmpjwvpycrg
184M    /home/kota/.cache/pfio/tmpjwvpycrg
```

## Concurrency control

- For threads: while `pread()` and `pwrite()` are thread-safe, other internal data structure such as known ranges is not thread safe. This is future work.
- For processes: POSIX doesn't guarantee consistent read and write against single file by multiple processes; and little is also supported in Linux. Same technique as we do in `pfio.cache.MultiprocessFileCache` can be applied to the class `CachedWrapper()`. This is also future work.