### PR TITLE
Limit the sparse cache size

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -9,7 +9,7 @@ configs{
     }
     # https://github.pfidev.jp/ci/imosci/blob/master/proto/data.proto#L933
     time_limit {
-      seconds: 900 # 15 minutes
+      seconds: 1200 # 20 minutes
     }
     command:
         "bash .pfnci/script.sh"
@@ -26,7 +26,7 @@ configs{
     }
     # https://github.pfidev.jp/ci/imosci/blob/master/proto/data.proto#L933
     time_limit {
-      seconds: 600 # 15 minutes
+      seconds: 900 # 15 minutes
     }
     command:
         "bash .pfnci/script-old.sh"

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -3,8 +3,8 @@ configs{
   key: "chainerio"
   value {
     requirement {
-      cpu: 2
-      memory: 6
+      cpu: 4
+      memory: 16
       disk: 10
     }
     # https://github.pfidev.jp/ci/imosci/blob/master/proto/data.proto#L933

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -75,6 +75,7 @@ class _CachedWrapperBase:
         else:
             self.lock = DummyLock()
 
+        self.pos = 0
         self.size = size
         assert size > 0
         if cachedir is None:
@@ -379,8 +380,10 @@ class CachedWrapper(_CachedWrapperBase):
 
         start = self.pos // self.pagesize
         end = (self.pos + size) // self.pagesize
+        if (self.pos + size) % self.pagesize != 0:
+            end += 1
 
-        for i in range(start, end + 1):
+        for i in range(start, end):
             # print('range=', i, "total=", len(self.ranges))
             r = self.ranges[i]
 
@@ -533,8 +536,10 @@ class MPCachedWrapper(CachedWrapper):
 
         start = self.pos // self.pagesize
         end = (self.pos + size) // self.pagesize
+        if (self.pos + size) % self.pagesize != 0:
+            end += 1
 
-        for i in range(start, end + 1):
+        for i in range(start, end):
             with _shflock(self.indexfd):
                 r = self._get_index(i)
 

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -567,8 +567,10 @@ class MPCachedWrapper(CachedWrapper):
         # If the cache file is more than the limit, just flush them all.
         if is_full:
             with _exflock(self.indexfd):
-                os.truncate(self.cachefd, 0)
-                self._init_indexfile()
+                is_full = self._is_full()
+                if is_full:
+                    os.truncate(self.cachefd, 0)
+                    self._init_indexfile()
 
         return buf
 

--- a/tests/cache_tests/test_sparse_file.py
+++ b/tests/cache_tests/test_sparse_file.py
@@ -188,9 +188,9 @@ def test_cache(pagesize, klass):
 
         with open(filepath, 'rb') as ofp:
             with klass(ofp, len(data), pagesize=pagesize) as fp:
-                for i in range(1024*1024):
+                for i in range(1024*16):
                     assert not fp._is_full()
-                    assert pb == fp.read(16)
+                    assert pb*64 == fp.read(1024)
 
 
 @pytest.mark.parametrize("klass", [SparseFileCache,
@@ -210,6 +210,6 @@ def test_cache_limit(pagesize, limit, klass):
 
             with klass(ofp, len(data), pagesize=pagesize,
                        cache_size_limit=limit) as fp:
-                for i in range(1024*1024):
+                for i in range(1024*16):
                     assert not fp._is_full()
-                    assert pb == fp.read(16)
+                    assert pb*64 == fp.read(1024)


### PR DESCRIPTION
Can be used like
```python
  with from_url("s3://path/to/foo.zip", local_cache=True, reset_on_fork=True,
                cache_size_limit=4096*4096) as s3:
    s3.open.read()
```