### PR TITLE
S3 + zipfile on fork-server multiprocessing

### DIFF
--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -124,6 +124,15 @@ class Zip(FS):
         assert self.fileobj is not None
         self.zipobj = zipfile.ZipFile(self.fileobj, self.mode)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['fileobj'] = None
+        state['zipobj'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     package_data={'pfio': package_data},
     extras_require={
-        'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto', 'numpy'],
+        'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto[server]', 'numpy'],
         # When updating doc deps, docs/requirements.txt should be updated too
         'doc': ['sphinx', 'sphinx_rtd_theme'],
         'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -7,7 +7,7 @@ import traceback
 import zipfile
 
 import pytest
-from moto import mock_s3
+from moto import mock_s3, server
 
 import pfio
 from pfio.testing import ZipForTest
@@ -56,8 +56,22 @@ def test_s3_zip(local_cache):
                 assert zft.content('file') == fp.read()
 
 
-@mock_s3
-def test_s3_zip_mp():
+@pytest.mark.parametrize("mp_start_method", ["fork", "forkserver"])
+def test_s3_zip_mp(mp_start_method):
+    # mock_s3 doesn't work well in forkserver, thus we use server-mode moto
+    address = "127.0.0.1"
+    port = 5000
+    moto_server = server.ThreadedMotoServer(
+        ip_address=address,
+        port=port
+    )
+    moto_server.start()
+
+    kwargs = {
+        "endpoint": f"http://{address}:{port}",
+        "aws_access_key_id": "",
+        "aws_secret_access_key": "",
+    }
     with tempfile.TemporaryDirectory() as d:
         n_workers = 32
         n_samples_per_worker = 1024
@@ -71,39 +85,32 @@ def test_s3_zip_mp():
         zipfilename = os.path.join(d, "test.zip")
         _ = ZipForTest(zipfilename, data)
         bucket = "test-dummy-bucket"
-        q = multiprocessing.Queue()
+
+        mp_ctx = multiprocessing.get_context(mp_start_method)
+        q = mp_ctx.Queue()
 
         # Copy ZIP
         with from_url('s3://{}/'.format(bucket),
-                      create_bucket=True) as s3:
+                      create_bucket=True, **kwargs) as s3:
             assert isinstance(s3, S3)
-            with open(zipfilename, 'rb') as src,\
+            with open(zipfilename, 'rb') as src, \
                     s3.open('test.zip', 'wb') as dst:
                 shutil.copyfileobj(src, dst)
 
             with s3.open('test.zip', 'rb') as fp:
                 assert zipfile.is_zipfile(fp)
 
-        def child(zfs, worker_idx):
-            try:
-                for i in range(n_samples_per_worker):
-                    sample_idx = (
-                        worker_idx * n_samples_per_worker + i) // sample_size
-                    filename = 'dir/file-{}'.format(sample_idx)
-                    with zfs.open(filename, 'rb') as fp:
-                        data1 = fp.read()
-                    assert data['dir']['file-{}'.format(sample_idx)] == data1
-                q.put(('ok', None))
-            except Exception as e:
-                traceback.print_tb()
-                q.put(('ng', e))
-
         with from_url('s3://{}/test.zip'.format(bucket),
-                      local_cache=True, reset_on_fork=True) as fs:
+                      local_cache=True, reset_on_fork=True,
+                      **kwargs) as fs:
 
             # Add tons of data into the cache in parallel
 
-            ps = [multiprocessing.Process(target=child, args=(fs, worker_idx))
+            ps = [mp_ctx.Process(target=s3_zip_mp_child,
+                                 args=(q, fs, worker_idx,
+                                       n_samples_per_worker, sample_size,
+                                       data)
+                                 )
                   for worker_idx in range(n_workers)]
             for p in ps:
                 p.start()
@@ -113,9 +120,27 @@ def test_s3_zip_mp():
                 assert 'ok' == ok, str(e)
 
             for worker_idx in range(n_workers):
-                child(fs, worker_idx)
+                s3_zip_mp_child(q, fs, worker_idx,
+                                n_samples_per_worker, sample_size, data)
                 ok, e = q.get()
                 assert 'ok' == ok, str(e)
+
+    moto_server.stop()
+
+
+def s3_zip_mp_child(q, zfs, worker_idx,
+                    n_samples_per_worker, sample_size, data):
+    try:
+        for i in range(n_samples_per_worker):
+            sample_idx = (worker_idx * n_samples_per_worker + i) // sample_size
+            filename = 'dir/file-{}'.format(sample_idx)
+            with zfs.open(filename, 'rb') as fp:
+                data1 = fp.read()
+            assert data['dir']['file-{}'.format(sample_idx)] == data1
+        q.put(('ok', None))
+    except Exception as e:
+        traceback.print_tb()
+        q.put(('ng', e))
 
 
 @mock_s3

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -60,12 +60,13 @@ def test_s3_zip(local_cache):
 def test_s3_zip_mp(mp_start_method):
     # mock_s3 doesn't work well in forkserver, thus we use server-mode moto
     address = "127.0.0.1"
-    port = 5000
+    port = 0  # auto-selection
     moto_server = server.ThreadedMotoServer(
         ip_address=address,
         port=port
     )
     moto_server.start()
+    port = moto_server._server.port
 
     kwargs = {
         "endpoint": f"http://{address}:{port}",


### PR DESCRIPTION
Current PFIO doesn't support S3 + zipfile on fork-server based multiprocessing execution model.
This model requires parameters given to Process should be pickled to move object from child to parent, who has responsibility to fork an new process.

https://github.com/pfnet/pfio/pull/292/commits/dffff08c83c3fb52147ab53029d212625828a1c3 solves this issue by avoiding pickling of fileobj and zipobj, then after fork, it will be re-created by zip and S3's _reset() functions.