### PR TITLE
Refine pfio.cache.HTTPCache

### DIFF
--- a/pfio/cache/http_cache.py
+++ b/pfio/cache/http_cache.py
@@ -72,7 +72,7 @@ class HTTPCache(Cache):
         self.do_pickle = do_pickle
 
         # Allow redirect or retry once
-        self.conn = urllib3.poolmanager.PoolManager(retries=1)
+        self.conn = urllib3.poolmanager.PoolManager(retries=1, timeout=3)
 
     def __len__(self):
         return self.length

--- a/pfio/cache/http_cache.py
+++ b/pfio/cache/http_cache.py
@@ -71,7 +71,8 @@ class HTTPCache(Cache):
 
         self.do_pickle = do_pickle
 
-        self.conn = urllib3.poolmanager.PoolManager()
+        # Allow redirect or retry once
+        self.conn = urllib3.poolmanager.PoolManager(retries=1)
 
     def __len__(self):
         return self.length

--- a/pfio/cache/http_cache.py
+++ b/pfio/cache/http_cache.py
@@ -80,8 +80,8 @@ class HTTPCache(Cache):
     def is_forked(self):
         return self.pid != os.getpid()
 
-    def _checkfork(self):
-        if self.is_forked:
+    def _checkconn(self):
+        if self.is_forked or self.conn is None:
             self._prepare_conn()
             self.pid = os.getpid()
 
@@ -109,7 +109,7 @@ class HTTPCache(Cache):
         return True
 
     def put(self, i, data):
-        self._checkfork()
+        self._checkconn()
         if i < 0 or self.length <= i:
             raise IndexError("index {} out of range ([0, {}])"
                              .format(i, self.length - 1))
@@ -132,7 +132,7 @@ class HTTPCache(Cache):
         return False
 
     def get(self, i):
-        self._checkfork()
+        self._checkconn()
         if i < 0 or self.length <= i:
             raise IndexError("index {} out of range ([0, {}])"
                              .format(i, self.length - 1))

--- a/pfio/cache/http_cache.py
+++ b/pfio/cache/http_cache.py
@@ -1,7 +1,7 @@
+import logging
 import os
 import pickle
 import time
-import logging
 
 import urllib3
 import urllib3.exceptions


### PR DESCRIPTION
This PR refines HTTPCache to support fault-tolerance and multiprocessing with fork-server execution model.

- https://github.com/pfnet/pfio/commit/8ab92dfde2a0bcac909eb298b6bf732df50bc122
  - Reports error (i.e. unexpected HTTP status code or exception) to user instead of stop working
- https://github.com/pfnet/pfio/commit/36b1df82de8a0fe6f4547580c007d0fbeb4ee9b4
  - We can expect that the HTTP backend doesn't return many redirect or errors, so we limit the number of retries to one.
- https://github.com/pfnet/pfio/commit/b138d89c923259dff13837bc572792e991d6f33c
  - We can expect that the HTTP backend processes requests faster I/O, so we shorten the timeout.
- https://github.com/pfnet/pfio/commit/72c9da444218912ccd652881f0cf2067bb382cfe
  - multiprocessing with fork-server execution model requires picklable parameters. The connection pool doesn't support pickle so we re-create the pool if we detected the fork.