### PR TITLE
Flake8 skip for Python 3.7

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -20,8 +20,8 @@ configs{
   key: "pfio.old-python" # Tests that test old python versions, e.g. python 3.6
   value {
     requirement {
-      cpu: 1
-      memory: 6
+      cpu: 4
+      memory: 16
       disk: 10
     }
     # https://github.pfidev.jp/ci/imosci/blob/master/proto/data.proto#L933

--- a/.pfnci/docker/Dockerfile
+++ b/.pfnci/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
 
 ADD pyenv.tar.gz /root/
 # RUN ls /root
-RUN mv /root/pyenv-2.3.4 /root/.pyenv
+RUN mv /root/pyenv-2.3.9 /root/.pyenv
 ENV PYENV_ROOT /root/.pyenv
 
 # COPY install-pyenv.sh /tmp/install-pyenv.sh
@@ -21,10 +21,11 @@ RUN $PYENV_ROOT/plugins/python-build/install.sh
 ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 ENV MAKE_OPTS "-j12"
 
-RUN pyenv install 3.10.6
-RUN pyenv install 3.7.13
-RUN pyenv install 3.8.13
-RUN pyenv install 3.9.13
-RUN pyenv global 3.10.6
+RUN pyenv install 3.11.1
+RUN pyenv install 3.10.9
+RUN pyenv install 3.7.16
+RUN pyenv install 3.8.16
+RUN pyenv install 3.9.16
+RUN pyenv global 3.11.1
 
-RUN pip install tox
+# RUN pip install tox

--- a/.pfnci/docker/Makefile
+++ b/.pfnci/docker/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 pyenv.tar.gz:
-	wget https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.4.tar.gz -O $@
+	wget https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.9.tar.gz -O $@
 
 build: pyenv.tar.gz
 	@docker build -t asia-northeast1-docker.pkg.dev/pfn-artifactregistry/public-ci-pfio/pfio:latest .

--- a/.pfnci/test-old.sh
+++ b/.pfnci/test-old.sh
@@ -7,4 +7,4 @@ export PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 pyenv global 3.7.16 3.8.16 3.9.16
 python -m pip install --upgrade pip
 pip install tox
-tox -r -e py37,py38,py39
+tox -p 3 -r -e py37,py38,py39

--- a/.pfnci/test-old.sh
+++ b/.pfnci/test-old.sh
@@ -4,8 +4,7 @@ set -eux
 export PYENV_ROOT=$HOME/.pyenv
 
 export PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
-pyenv global 3.7.13 3.8.13
+pyenv global 3.7.16 3.8.16 3.9.16
 python -m pip install --upgrade pip
 pip install tox
-pip install -e .[test]
-tox -e py37,py38
+tox -r -e py37,py38,py39

--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -4,16 +4,7 @@ set -eux
 export PYENV_ROOT=$HOME/.pyenv
 
 export PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
-pyenv global 3.9.13 3.10.6
-tox -e py39,py310 && :
-tox_status=$?
-
-# test doc, needs python >= 3.6
-pyenv global 3.10.6
-pip install .[doc]
-cd docs && make html && :
-sphinx_status=$?
-
-echo "tox_status=${tox_status}"
-echo "sphinx_status=${sphinx_status}"
-exit $((tox_status || sphinx_status))
+pyenv global 3.10.9 3.11.1
+python -m pip install --upgrade pip
+pip install tox
+tox -r -e py310,py311,doc

--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -7,4 +7,4 @@ export PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 pyenv global 3.10.9 3.11.1
 python -m pip install --upgrade pip
 pip install tox
-tox -r -e py310,py311,doc
+tox -p 3 -r -e py310,py311,doc

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'doc': ['sphinx', 'sphinx_rtd_theme'],
         'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     # When updating install requires, docs/requirements.txt should be updated too
     install_requires=['pyarrow>=6.0.0', 'boto3', 'deprecation', 'urllib3'],
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,4 @@ setenv =
 changedir = docs
 commands =
         make html
+allowlist_externals=make

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,33 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311,doc
 
 [testenv]
 deps = .[test]
 skipsdist = True
-setenv = 
+setenv =
         HOME = "/root"
 commands =
-	pytest -W error::deprecation.UnsupportedWarning tests -s -v
-	flake8 pfio
-	flake8 tests
-	autopep8 -r pfio tests --diff
-	isort . --check --diff
+        flake8 pfio tests
+        autopep8 -r pfio tests --diff
+        isort . --check --diff
+        pytest -W error::deprecation.UnsupportedWarning tests -s -v
+
+# Rule out flake8 as wrong version (2.5.5) is installed somehow
+[testenv:py37]
+deps = .[test]
+skipsdist = True
+setenv =
+        HOME = "/root"
+commands =
+        autopep8 -r pfio tests --diff
+        isort . --check --diff
+        pytest -W error::deprecation.UnsupportedWarning tests -s -v
+
+[testenv:doc]
+deps = .[doc]
+skipsdist = True
+setenv =
+        HOME = "/root"
+changedir = docs
+commands =
+        make html


### PR DESCRIPTION
Master CI is failing like this:
```
py37: commands[1]> flake8 pfio
/repo/.tox/py37/lib/python3.7/site-packages/pep8.py:110: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
pfio/cache/__init__.py:65:1: F401 'MultiprocessSparseFileCache' imported but unused
Traceback (most recent call last):
  File "/repo/.tox/py37/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/repo/.tox/py37/lib/python3.7/site-packages/flake8/main.py", line 36, in main
    report = flake8_style.check_files()
  File "/repo/.tox/py37/lib/python3.7/site-packages/flake8/engine.py", line 181, in check_files
    return self._retry_serial(self._styleguide.check_files, paths=paths)
  File "/repo/.tox/py37/lib/python3.7/site-packages/flake8/engine.py", line 172, in _retry_serial
    return func(*args, **kwargs)                                                                             [9/1808]
  File "/repo/.tox/py37/lib/python3.7/site-packages/pep8.py", line 1841, in check_files
    self.input_dir(path)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pep8.py", line 1877, in input_dir
    runner(os.path.join(root, filename))
  File "/repo/.tox/py37/lib/python3.7/site-packages/flake8/engine.py", line 126, in input_file
    return fchecker.check_all(expected=expected, line_offset=line_offset)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pep8.py", line 1575, in check_all
    self.check_ast()
  File "/repo/.tox/py37/lib/python3.7/site-packages/pep8.py", line 1521, in check_ast
    checker = cls(tree, self.filename)
  File "/repo/.tox/py37/lib/python3.7/site-packages/flake8/_pyflakes.py", line 62, in __init__
    withDoctest=withDoctest)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pyflakes/checker.py", line 294, in __init__
    self.handleChildren(tree)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pyflakes/checker.py", line 567, in handleChildren
    self.handleNode(node, tree)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pyflakes/checker.py", line 609, in handleNode
    handler(node)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pyflakes/checker.py", line 867, in CLASSDEF
    self.handleNode(stmt, node)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pyflakes/checker.py", line 608, in handleNode
    handler = self.getNodeHandler(node.__class__)
  File "/repo/.tox/py37/lib/python3.7/site-packages/pyflakes/checker.py", line 462, in getNodeHandler
    self._nodeHandlers[node_class] = handler = getattr(self, nodeType)
AttributeError: 'FlakesChecker' object has no attribute 'ANNASSIGN'
```

In the tox venv, `flake8==2.5.5` is installed (reported by @y1r ) and somehow old version is installed even though the latest version of flake8 is now 5 (or 6 depending on the env). The root cause isn't identified yet ( it seems that something is old in the dependency chain ), for now, we're skipping flake8 test only for Python 3.7. It's EoL will be next June ( see: https://peps.python.org/pep-0537/ ), it won't last so long.

Also, this patch includes several environment updates including:
- Docker image update
- Python 3.11 addition
- Pyenv update
- Minor updates of each Python version
- Move doc build test from shell to one of tox env in the list
- Parallelization of tox env runs for each Python version as well as increase of the CPU (2x faster test run)