### PR TITLE
Remove reset_on_fork parameter

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -39,6 +39,13 @@ Zip Archive
 .. autoclass:: pfio.v2.Zip
    :members:
 
+Error
+~~~~~
+
+.. autoclass:: pfio.v2.fs.ForkedError
+   :members:
+
+
 Pathlib-like API
 ~~~~~~~~~~~~~~~~
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -39,13 +39,6 @@ Zip Archive
 .. autoclass:: pfio.v2.Zip
    :members:
 
-Error
-~~~~~
-
-.. autoclass:: pfio.v2.fs.ForkedError
-   :members:
-
-
 Pathlib-like API
 ~~~~~~~~~~~~~~~~
 

--- a/pfio/cache/sparse_file.py
+++ b/pfio/cache/sparse_file.py
@@ -451,9 +451,7 @@ class MPCachedWrapper(CachedWrapper):
         import os
         from pfio.v2 import from_url
 
-        with from_url("s3://bucket/your.zip",
-                      local_cache=True, reset_on_fork=True) as fs:
-
+        with from_url("s3://bucket/your.zip", local_cache=True) as fs:
           pid = os.fork()
           if pid:
             os.wait()

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import os
 import stat
+import warnings
 from abc import abstractmethod
 from io import IOBase
 from types import TracebackType
@@ -342,7 +343,11 @@ def from_url(url: str, **kwargs) -> 'FS':
 
     '''
     if kwargs.pop('reset_on_fork', None) is not None:
-        print("reset_on_fork is deprecated. PFIO resets on fork by default")
+        warnings.warn(
+            "reset_on_fork is deprecated. PFIO resets on fork by default",
+            category=DeprecationWarning,
+            stacklevel=2
+        )
 
     parsed = urlparse(url)
     if parsed.scheme:

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -67,6 +67,18 @@ class FileStat(abc.ABC):
         return str(self.__str__())
 
 
+class ForkedError(RuntimeError):
+    '''An error class when PFIO found the process forked.
+
+    If an FS object is not "lazy", any object usage detects process
+    fork and raises this ``ForkedError`` as soon as possible at the
+    child process. The parent process may or may not run well,
+    depending on the ``FS`` implementation.
+
+    '''
+    pass
+
+
 class FS(abc.ABC):
     '''FS access abstraction
 

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -182,7 +182,9 @@ class Hdfs(FS):
 
 
     .. warning:: It is strongly discouraged to use :class:`Hdfs` under
-          multiprocessing. If you do *need* forking, for example, PyTorch
+          multiprocessing. Once the object detects the process id changed
+          (which means it is forked), the object raises :class:`ForkedError`
+          before doing anything. If you do *need* forking, for example, PyTorch
           DataLoader with multiple workers for performance, it is strongly
           recommended not to instantiate :class:`Hdfs` before forking. Details
           are described in PFIO issue #123.  Simple workaround is to set

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -11,7 +11,7 @@ from xml.etree import ElementTree
 import pyarrow
 from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
 
-from .fs import FS, FileStat
+from .fs import FS, FileStat, ForkedError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -236,10 +236,13 @@ class Hdfs(FS):
             else:
                 raise ValueError('{} must be a directory'.format(self.cwd))
 
-    def _reset(self):
         if multiprocessing.get_start_method() != 'forkserver':
             # See https://github.com/pfnet/pfio/pull/123 for detail
             warnings.warn('Non-forkserver start method under HDFS detected.')
+
+    def _reset(self):
+        if multiprocessing.get_start_method() != 'forkserver':
+            raise ForkedError()
 
         self._fs = _create_fs()
 

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -182,14 +182,10 @@ class Hdfs(FS):
 
 
     .. warning:: It is strongly discouraged to use :class:`Hdfs` under
-          multiprocessing. Setting ``reset_on_fork=False`` is
-          recommended for HDFS in order not to shoot yourself in the
-          foot, because forking a JVM instance that has a different
-          memory model may cause unexpected behavior. If you do *need*
-          forking, for example, PyTorch DataLoader with multiple
-          workers for performance, it is strongly recommended not to
-          instantiate :class:`Hdfs` before forking. Details are
-          described in PFIO issue #123.  Simple workaround is to set
+          multiprocessing. If you do *need* forking, for example, PyTorch
+          DataLoader with multiple workers for performance, it is strongly
+          recommended not to instantiate :class:`Hdfs` before forking. Details
+          are described in PFIO issue #123.  Simple workaround is to set
           multiprocessing start method as ``'forkserver'`` and start
           the very first child process before everything.
 
@@ -216,8 +212,8 @@ class Hdfs(FS):
 
     '''
 
-    def __init__(self, cwd=None, create=False, reset_on_fork=False, **_):
-        super().__init__(reset_on_fork=reset_on_fork)
+    def __init__(self, cwd=None, create=False, **_):
+        super().__init__()
         self._fs = _create_fs()
         assert self._fs is not None
         self.username = self._get_principal_name()
@@ -238,12 +234,11 @@ class Hdfs(FS):
             else:
                 raise ValueError('{} must be a directory'.format(self.cwd))
 
-        if reset_on_fork and\
-           multiprocessing.get_start_method() != 'forkserver':
+    def _reset(self):
+        if multiprocessing.get_start_method() != 'forkserver':
             # See https://github.com/pfnet/pfio/pull/123 for detail
             warnings.warn('Non-forkserver start method under HDFS detected.')
 
-    def _reset(self):
         self._fs = _create_fs()
 
     def __getstate__(self):

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -43,8 +43,8 @@ class LocalFileStat(FileStat):
 
 
 class Local(FS):
-    def __init__(self, cwd=None, create=False, reset_on_fork=False, **_):
-        super().__init__(reset_on_fork=reset_on_fork)
+    def __init__(self, cwd=None, create=False, **_):
+        super().__init__()
 
         if cwd is None:
             self._cwd = ''

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -307,9 +307,8 @@ class S3(FS):
                  mpu_chunksize=32*1024*1024,
                  buffering=-1,
                  create=False,
-                 reset_on_fork=False,
                  **_):
-        super().__init__(reset_on_fork=reset_on_fork)
+        super().__init__()
         self.bucket = bucket
         self.create_bucket = create_bucket
         if prefix is not None:

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -4,7 +4,7 @@ import os
 import zipfile
 from datetime import datetime
 
-from pfio.cache.sparse_file import CachedWrapper, MPCachedWrapper
+from pfio.cache.sparse_file import MPCachedWrapper
 
 from .fs import FS, FileStat
 
@@ -58,9 +58,8 @@ class Zip(FS):
     '''
 
     def __init__(self, backend, file_path, mode='r', create=False,
-                 local_cache=False, local_cachedir=None,
-                 reset_on_fork=False, **kwargs):
-        super().__init__(reset_on_fork=reset_on_fork)
+                 local_cache=False, local_cachedir=None, **kwargs):
+        super().__init__()
         self.backend = backend
         self.file_path = file_path
         self.mode = mode
@@ -101,21 +100,17 @@ class Zip(FS):
         if self.local_cache:
             self.kwargs['buffering'] = buffering
 
-            if self.reset_on_fork:
-                obj = MPCachedWrapper(obj, stat.size, self.local_cachedir,
-                                      local_cachefile=self.local_cachefile,
-                                      local_indexfile=self.local_indexfile,
-                                      close_on_close=True,
-                                      multithread_safe=True)
+            obj = MPCachedWrapper(obj, stat.size, self.local_cachedir,
+                                  local_cachefile=self.local_cachefile,
+                                  local_indexfile=self.local_indexfile,
+                                  close_on_close=True,
+                                  multithread_safe=True)
 
-                # Update local cachefile in case of being forked
-                self.local_cachefile = obj.local_cachefile
-                self.local_indexfile = obj.local_indexfile
-            else:
-                obj = CachedWrapper(obj, stat.size, self.local_cachedir,
-                                    close_on_close=True, multithread_safe=True)
+            # Update local cachefile in case of being forked
+            self.local_cachefile = obj.local_cachefile
+            self.local_indexfile = obj.local_indexfile
 
-                # Default 16MB buffer size
+            # Default 16MB buffer size
             if buffering > 0:
                 obj = io.BufferedReader(obj, buffer_size=buffering)
 

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -99,7 +99,7 @@ def test_s3_zip_mp():
                 q.put(('ng', e))
 
         with from_url('s3://{}/test.zip'.format(bucket),
-                      local_cache=True, reset_on_fork=True) as fs:
+                      local_cache=True) as fs:
 
             # Add tons of data into the cache in parallel
 

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -584,11 +584,10 @@ class TestZipWithLargeData(unittest.TestCase):
                 f.read()
 
             def func():
-                # accessing the shared container isn't supported in v2
-                with self.assertRaises(RuntimeError):
-                    with z.open(self.testfile_name) as f:
-                        barrier.wait()
-                        f.read()
+                # accessing the shared container is supported by reset
+                with z.open(self.testfile_name) as f:
+                    barrier.wait()
+                    assert f.read()
 
             p1 = multiprocessing.Process(target=func)
             p2 = multiprocessing.Process(target=func)


### PR DESCRIPTION
Fixes https://github.com/pfnet/pfio/issues/296

- Removed `reset_on_fork` parameter from all FS implementations
- ~Removed `ForkedError` because we don't need it now~
- Added `reset_on_fork` parameter check on `from_url` to notify the deprecation

I've found that, in zip + SparseFileCache case, we always use MPCachedWrapper instead of CachedWrapper because we don't have prior information of fork existence by `reset_on_fork` parameter. This may introduce performance decrease by `flock(2)`.