### PR TITLE
Fix broken sphinx reference

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -143,7 +143,7 @@ repetitive access to the data collection.
    Therefore load the data from the storage only when necessary,
    which is at the first access to each data.
 
-PFIO cache API provides :class:`~NaiveCache`, :class:`~FileCache`and
+PFIO cache API provides :class:`~NaiveCache`, :class:`~FileCache` and
 :class:`~MultiprocessFileCache`.
 They all share the same core idea and interface.
 The difference is how to manage the cached data.


### PR DESCRIPTION
Just fixing the reference.

Before | After
-- | --
![Screenshot 2023-03-24 at 0 39 01](https://user-images.githubusercontent.com/5164000/227256637-356403ef-5f58-432e-818b-51955bd99217.jpg) | ![Screenshot 2023-03-24 at 0 39 52](https://user-images.githubusercontent.com/5164000/227256661-7667dd4c-0787-4b8d-a57e-7a6a87ca7730.jpg)

https://pfio.readthedocs.io/en/latest/reference.html#cache-api