### PR TITLE
Make HDFS optional

### DIFF
--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -8,8 +8,12 @@ import subprocess
 import warnings
 from xml.etree import ElementTree
 
-import pyarrow
-from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
+try:
+    import pyarrow
+    from pyarrow.fs import FileSelector, FileType, HadoopFileSystem
+    has_hdfs = True
+except ImportError:
+    has_hdfs = False
 
 from .fs import FS, FileStat, ForkedError
 

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,10 @@ setup(
         # When updating doc deps, docs/requirements.txt should be updated too
         'doc': ['sphinx', 'sphinx_rtd_theme'],
         'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],
+        'hdfs': ['pyarrow>=6.0.0'],
     },
     # When updating install requires, docs/requirements.txt should be updated too
-    install_requires=['pyarrow>=6.0.0', 'boto3', 'deprecation', 'urllib3'],
+    install_requires=['boto3', 'deprecation', 'urllib3'],
     include_package_data=True,
     zip_safe=False,
 

--- a/tests/v2_tests/test_hdfs.py
+++ b/tests/v2_tests/test_hdfs.py
@@ -9,7 +9,13 @@ import unittest
 from collections.abc import Iterable
 
 import pytest
-from pyarrow import hdfs
+
+try:
+    from pyarrow import hdfs
+    has_hdfs = True
+except ImportError:
+    has_hdfs = False
+
 
 from pfio.testing import randstring
 from pfio.v2 import from_url, open_url

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ commands =
 [testenv:doc]
 deps = .[doc]
 skipsdist = True
-setenv =
-        HOME = "/root"
 changedir = docs
 commands =
         make html


### PR DESCRIPTION
After 2.6.0, to use HDFS connector, do `pip install pfio[hdfs]` .