### PR TITLE
Fix Path.glob for compatibility with standard pathlib.Path

### DIFF
--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -129,11 +129,13 @@ class FS(abc.ABC):
         elif '..' in rel_path.split(os.path.sep):
             raise RuntimeError("Only subtree is supported")
 
-        sub = copy.copy(self)
+        return self._newfs(os.path.join(self.cwd, rel_path))
 
-        sub._cwd = os.path.join(self.cwd, rel_path)
-        sub._reset()
-        return sub
+    def _newfs(self, path: str) -> 'FS':
+        fs = copy.copy(self)
+        fs._cwd = path
+        fs._reset()
+        return fs
 
     def _checkfork(self):
         if not self.is_forked:
@@ -287,6 +289,11 @@ class FS(abc.ABC):
                    all the files and directories under it will be removed.
                    When the path is a file, this option is ignored.
 
+        """
+        raise NotImplementedError()
+
+    def glob(self, pattern: str) -> Iterator[Union[FileStat, str]]:
+        """Returns the files and dictories that match the glob pattern.
         """
         raise NotImplementedError()
 

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -1,5 +1,6 @@
 import io
 import os
+import pathlib
 import shutil
 from typing import Optional
 
@@ -152,3 +153,8 @@ class Local(FS):
             return os.rmdir(file_path)
 
         return os.remove(file_path)
+
+    def glob(self, pattern: str):
+        return [
+            str(item.relative_to(self.cwd))
+            for item in pathlib.Path(self.cwd).glob(pattern)]


### PR DESCRIPTION
Fixed `Path.glob()` for compatibility with standard `pathlib.Path`.

* Made it hierarchy aware. Before `Path.glob("*")` returned all the entries in a recursive manner.
* Fixed so that the base path (on which the glob operation is performed) is included in the returned paths. Before they were relative to the base path.
* Omit trailing `/` for returned directory paths.

Along with that, I did several related changes:

* Refactored internal data of the `Path` class. Specifically, `_root` is merged to `_parts`.
* Added `Path.iterdir()`, `Path.parts` and `Path.root` for compatibility with standard `pathlib.Path`.
