### PR TITLE
Fix pathlib name to follow standard pathlib.Path

### DIFF
--- a/pfio/v2/pathlib.py
+++ b/pfio/v2/pathlib.py
@@ -37,7 +37,7 @@ class Path:
     @property
     def name(self):
         filename = self._root if not self._parts else self._parts[-1]
-        return os.path.normpath(filename)
+        return os.path.basename(os.path.normpath(filename))
 
     @property
     def suffix(self):

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -5,7 +5,10 @@ from pfio.v2 import S3, from_url, pathlib
 import pathlib as python_pathlib
 
 
-@pytest.mark.parametrize("test_path", ["foo.txt", "foo/", "dir/foo/", "dir/foo.txt" "/foo"])
+@pytest.mark.parametrize(
+    "test_path",
+    ["foo.txt", "foo/", "dir/foo/", "dir/foo.txt" "/foo"]
+)
 def test_name(test_path):
     pfio_path = pathlib.Path(test_path)
     python_path = python_pathlib.Path(test_path)

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -1,14 +1,15 @@
+import pytest
 from moto import mock_s3
 
 from pfio.v2 import S3, from_url, pathlib
+import pathlib as python_pathlib
 
 
-def test_name():
-    p = pathlib.Path('foo.txt')
-    assert 'foo.txt' == p.name
-
-    p = pathlib.Path('foo/')
-    assert 'foo' == p.name
+@pytest.mark.parametrize("test_path", ["foo.txt", "foo/", "dir/foo/", "dir/foo.txt" "/foo"])
+def test_name(test_path):
+    pfio_path = pathlib.Path(test_path)
+    python_path = python_pathlib.Path(test_path)
+    assert pfio_path.name == python_path.name
 
 
 def test_suffix():
@@ -110,16 +111,16 @@ def test_s3_glob():
             files = list(d2.glob("*"))
             assert 10 == len(files)
             for f in files:
-                assert f.name.startswith('base/')
+                assert str(f).startswith('/base/')
 
             files = list(d2.glob("*/0"))
-            assert ['base/0'] == [f.name for f in files]
+            assert ['0'] == [f.name for f in files]
             for f in files:
-                assert f.name.startswith('base/')
+                assert str(f).startswith('/base/')
 
             paths = ['foo', 'bar', 'baz/foo', 'baz/hoge/boom/huga']
             for p in paths:
                 pathlib.Path(p, fs=s3).touch()
 
             d3 = pathlib.Path('baz', fs=s3)
-            assert ['hoge/boom/huga'] == [f.name for f in d3.glob('**/huga')]
+            assert ['hoge/boom/huga'] == [str(f) for f in d3.glob('**/huga')]

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -1,8 +1,9 @@
+import pathlib as python_pathlib
+
 import pytest
 from moto import mock_s3
 
 from pfio.v2 import S3, from_url, pathlib
-import pathlib as python_pathlib
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR matches the `pfio.v2.pathlib.Path.name` with standard pathlib.Path, which only return the file name of the file WITHOUT the directory.

```
import pathlib
import pfio.v2 as pfio

a = pathlib.Path("dir/file.txt")
b = pfio.pathlib.Path("dir/file.txt")

print(f"name from pathlib {a.name}")
print(f"name from pfio {b.name}")
```

output:
```
name from pathlib file.txt
name from pfio dir/file.txt
```

with this PR
```
name from pathlib file.txt
name from pfio file.txt
```