### PR TITLE
HTTPCachedFS

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -39,6 +39,12 @@ Zip Archive
 .. autoclass:: pfio.v2.Zip
    :members:
 
+HTTPCachedFS
+~~~~~~~~~~~~
+
+.. autoclass:: pfio.v2.HTTPCachedFS
+   :members:
+
 Error
 ~~~~~
 

--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -29,6 +29,7 @@ Or::
 '''
 from .fs import from_url, lazify, open_url  # NOQA
 from .hdfs import Hdfs, HdfsFileStat  # NOQA
+from .http_cache import HTTPCachedFS  # NOQA
 from .local import Local, LocalFileStat  # NOQA
 from .pathlib import Path  # NOQA
 from .s3 import S3  # NOQA

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -354,6 +354,8 @@ def from_url(url: str, **kwargs) -> 'FS':
         create (bool): Create the specified path doesn't exist.
 
         http_cache (str): Prefix url of http cached entries.
+            In the filesystem with http_cache specified, all read access will
+            be hooked and upload its content to the url with the given prefix.
             For details, please refer to :py:class:`pfio.v2.HTTPCachedFS`.
             (experimental feature)
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -315,7 +315,7 @@ def open_url(url: str, mode: str = 'r', **kwargs) -> Iterator[IOBase]:
        with open_url("s3://bucket.example.com/path/your-file.txt", 'r') as f:
            f.read()
 
-    .. note:: Some FS resouces won't be closed when using this
+    .. note:: Some FS resources won't be closed when using this
         functionality. See ``from_url`` for keyword arguments.
 
     Returns:
@@ -351,7 +351,11 @@ def from_url(url: str, **kwargs) -> 'FS':
 
         create (bool): Create the specified path doesn't exist.
 
-    .. note:: Some FS resouces won't be closed when using this
+        http_cache (str): Prefix url of http cached entries.
+            For details, please refer to ``HTTPCachedFS``.
+            (experimental feature)
+
+    .. note:: Some FS resources won't be closed when using this
         functionality.
 
     .. note:: Pickling the FS object may or may not work correctly
@@ -376,6 +380,8 @@ def from_url(url: str, **kwargs) -> 'FS':
     if force_type is not None and force_type != "zip":
         if force_type != scheme:
             raise ValueError("URL scheme mismatch with forced type")
+
+    http_cache_prefix = kwargs.pop("http_cache", None)
 
     def _zip_check_create_not_supported():
         if kwargs.get('create', False):
@@ -406,6 +412,10 @@ def from_url(url: str, **kwargs) -> 'FS':
     else:
         dirname = parsed.path
         fs = _from_scheme(scheme, dirname, kwargs, bucket=parsed.netloc)
+
+    if http_cache_prefix is not None:
+        from .http_cache import HTTPCachedFS
+        fs = HTTPCachedFS(http_cache_prefix, fs)
 
     return fs
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -298,8 +298,10 @@ class FS(abc.ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def normpath(self, file_path: str) -> str:
-        """Returns its normpath with protocol and endpoint
+    def _canonical_name(self, file_path: str) -> str:
+        """Returns its canonical name. Canonical name includes its filesystem
+        name, endpoint of filesystem, and file_path to represent its consistent
+        naming. Designed to be used in :py:class:`pfio.v2.HTTPCachedFS`.
         """
         raise NotImplementedError
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -352,7 +352,7 @@ def from_url(url: str, **kwargs) -> 'FS':
         create (bool): Create the specified path doesn't exist.
 
         http_cache (str): Prefix url of http cached entries.
-            For details, please refer to ``HTTPCachedFS``.
+            For details, please refer to :py:class:`pfio.v2.HTTPCachedFS`.
             (experimental feature)
 
     .. note:: Some FS resources won't be closed when using this

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -297,6 +297,12 @@ class FS(abc.ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def normpath(self, file_path: str) -> str:
+        """Returns its normpath with protocol and endpoint
+        """
+        raise NotImplementedError
+
 
 @contextlib.contextmanager
 def open_url(url: str, mode: str = 'r', **kwargs) -> Iterator[IOBase]:

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -381,4 +381,4 @@ class Hdfs(FS):
         path = os.path.join(self.cwd, file_path)
         norm_path = self._fs.normalize_path(path).rstrip('/')
 
-        return "hdfs({})/{}".format(self._nameservice, norm_path)
+        return f"hdfs://{self._nameservice}/{norm_path}"

--- a/pfio/v2/http_cache.py
+++ b/pfio/v2/http_cache.py
@@ -48,7 +48,9 @@ class HTTPCachedFS(FS):
                  fs: FS,
                  max_cache_size: int = 1024 * 1024 * 1024,
                  bearer_token_path: Optional[str] = None):
+        assert not isinstance(fs, HTTPCachedFS)
         super().__init__()
+
         self.fs = fs
         self.max_cache_size = max_cache_size
         self.conn = HTTPConnector(url, bearer_token_path)

--- a/pfio/v2/http_cache.py
+++ b/pfio/v2/http_cache.py
@@ -1,0 +1,224 @@
+import io
+from types import TracebackType
+from typing import Any, Iterator, Optional, Type, Union
+
+from pfio.cache import HTTPConnector
+
+from .fs import FS, FileStat
+
+
+class HTTPCachedFS(FS):
+    """HTTP-based cache system
+
+    Stores cache data in an HTTP server with ``PUT`` and ``GET`` methods. Each
+    cache entry corresponds to url suffixed by normalized paths (``normpath``).
+
+    Arguments:
+        url (string):
+            Prefix url of cache entries. Each entry corresponds to the url
+            suffixed by each normalized paths.
+
+        fs (pfio.v2.FS):
+            Underlying filesystem.
+
+            Read operations will be hooked by HTTPCachedFS to send a request to
+            the cache system. If the object is found in cache, the object will
+            be returned from cache without requesting to underlying fs.
+            Therefore, after the update of file in underlying fs, users have to
+            update url to avoid reading old data from the cache.
+
+            Other operations including write will not be hooked. It will be
+            transferred to underlying filesystem immediately.
+
+        bearer_token_path (string):
+            Path to HTTP bearer token if authorization required.
+            ``HTTPCachedFS`` supports refresh of bearer token by periodical
+            reloading.
+
+    .. note:: This feature is experimental.
+
+    """
+
+    def __init__(self,
+                 url: str,
+                 fs: FS,
+                 bearer_token_path: Optional[str] = None):
+        super().__init__()
+        self.fs = fs
+        self.conn = HTTPConnector(url, bearer_token_path)
+        if url.endswith("/"):
+            self.url = url
+        else:
+            self.url = url + "/"
+
+    def open(self,
+             file_path: str,
+             mode: str = 'rb',
+             *args, **kwargs) -> io.IOBase:
+        if 'r' in mode:
+            kwargs['mode'] = mode
+            return _HTTPCacheIOBase(file_path, self.conn, self.fs,
+                                    args, kwargs)
+        else:
+            return self.fs.open(file_path, mode, *args, **kwargs)
+
+    def _reset(self):
+        self.fs._reset()
+
+    def list(self, *args, **kwargs) -> Iterator[Union[FileStat, str]]:
+        return self.fs.list(*args, **kwargs)
+
+    def stat(self, *args, **kwargs) -> FileStat:
+        return self.fs.stat(*args, **kwargs)
+
+    def isdir(self, *args, **kwargs) -> bool:
+        return self.fs.isdir(*args, **kwargs)
+
+    def mkdir(self, *args, **kwargs) -> None:
+        return self.fs.mkdir(*args, **kwargs)
+
+    def makedirs(self, *args, **kwargs) -> None:
+        return self.fs.makedirs(*args, **kwargs)
+
+    def exists(self, *args, **kwargs) -> bool:
+        return self.fs.exists(*args, **kwargs)
+
+    def rename(self, *args, **kwargs) -> None:
+        return self.fs.rename(*args, **kwargs)
+
+    def remove(self, *args, **kwargs) -> None:
+        return self.fs.remove(*args, **kwargs)
+
+    def glob(self, pattern: str) -> Iterator[Union[FileStat, str]]:
+        return self.fs.glob(pattern)
+
+    def normpath(self, file_path: str) -> str:
+        # Don't add httpcache in normpath
+        return self.fs.normpath(file_path)
+
+
+class _HTTPCacheIOBase(io.RawIOBase):
+    def __init__(self,
+                 file_path: str,
+                 conn: HTTPConnector,
+                 fs: FS,
+                 open_args: Any, open_kwargs: dict):
+        super(_HTTPCacheIOBase, self).__init__()
+
+        self.file_path = file_path
+        self.conn = conn
+        self.fs = fs
+        self.open_args = open_args
+        self.open_kwargs = open_kwargs
+
+        self.cache_path = self.fs.normpath(self.file_path)
+        self.whole_file: Optional[bytes] = None
+        self.pos = 0
+        self._closed = False
+
+    def _load_file(self):
+        if self.whole_file is not None:
+            return
+
+        data = self.conn.get(self.cache_path)
+        if data is not None:
+            self.whole_file = data
+            return
+
+        with self.fs.open(self.file_path,
+                          *self.open_args, **self.open_kwargs) as f:
+            self.whole_file = f.read(-1)
+
+        if 1024 * 1024 * 1024 <= len(self.whole_file):
+            print(
+                "HTTPCachedFS: Too big data ({} bytes)".format(
+                    len(self.whole_file)
+                )
+            )
+            return
+
+        self.conn.put(self.cache_path, self.whole_file)
+
+    def read(self, size=-1) -> bytes:
+        self._load_file()
+        if self.whole_file is None:
+            print("HTTPCachedFS: failed to read from backend fs")
+            return b''
+
+        if len(self.whole_file) <= self.pos:
+            return b''
+        elif size <= 0:
+            data = self.whole_file[self.pos:]
+        else:
+            end = min(self.pos + size, len(self.whole_file))
+            data = self.whole_file[self.pos:end]
+
+        self.pos += len(data)
+        return data
+
+    def readline(self):
+        raise NotImplementedError()
+
+    def close(self):
+        self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]):
+        self.close()
+
+    def flush(self):
+        pass
+
+    @property
+    def closed(self):
+        return self._closed
+
+    def isatty(self):
+        return False
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def tell(self):
+        return self.pos
+
+    def truncate(self, size=None):
+        raise io.UnsupportedOperation('truncate')
+
+    def seek(self, pos, whence=io.SEEK_SET):
+        if whence in [0, io.SEEK_SET]:
+            if pos < 0:
+                raise OSError(22, "[Errno 22] Invalid argument")
+        elif whence in [1, io.SEEK_CUR]:
+            pos += self.pos
+        elif whence in [2, io.SEEK_END]:
+            self._load_file()
+            pos += len(self.whole_file)
+        else:
+            raise ValueError('Wrong whence value: {}'.format(whence))
+
+        if pos < 0:
+            raise OSError(22, "[Errno 22] Invalid argument")
+        self.pos = pos
+        return self.pos
+
+    def writable(self):
+        return False
+
+    def write(self, data):
+        raise io.UnsupportedOperation('not writable')
+
+    def readall(self):
+        return self.read(-1)
+
+    def readinto(self, b):
+        buf = self.read(len(b))
+        b[:len(buf)] = buf
+        return len(buf)

--- a/pfio/v2/http_cache.py
+++ b/pfio/v2/http_cache.py
@@ -11,7 +11,8 @@ class HTTPCachedFS(FS):
     """HTTP-based cache system
 
     Stores cache data in an HTTP server with ``PUT`` and ``GET`` methods. Each
-    cache entry corresponds to url suffixed by normalized paths (``normpath``).
+    cache entry corresponds to url suffixed by _canonical_name in
+    :py:class:`pfio.v2.fs.FS`.
 
     Arguments:
         url (string):
@@ -100,9 +101,9 @@ class HTTPCachedFS(FS):
     def glob(self, pattern: str) -> Iterator[Union[FileStat, str]]:
         return self.fs.glob(pattern)
 
-    def normpath(self, file_path: str) -> str:
+    def _canonical_name(self, file_path: str) -> str:
         # Don't add httpcache in normpath
-        return self.fs.normpath(file_path)
+        return self.fs._canonical_name(file_path)
 
 
 class _HTTPCacheIOBase(io.RawIOBase):
@@ -121,7 +122,7 @@ class _HTTPCacheIOBase(io.RawIOBase):
         self.open_args = open_args
         self.open_kwargs = open_kwargs
 
-        self.cache_path = self.fs.normpath(self.file_path)
+        self.cache_path = self.fs._canonical_name(self.file_path)
         self.whole_file: Optional[bytes] = None
         self.pos: Optional[int] = None
         self.fp: Optional[io.RawIOBase] = None

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -160,4 +160,4 @@ class Local(FS):
             for item in pathlib.Path(self.cwd).glob(pattern)]
 
     def _canonical_name(self, file_path: str) -> str:
-        return "local:/" + os.path.normpath(os.path.join(self.cwd, file_path))
+        return "file:/" + os.path.normpath(os.path.join(self.cwd, file_path))

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -159,5 +159,5 @@ class Local(FS):
             str(item.relative_to(self.cwd))
             for item in pathlib.Path(self.cwd).glob(pattern)]
 
-    def normpath(self, file_path: str) -> str:
-        return "local" + os.path.normpath(os.path.join(self.cwd, file_path))
+    def _canonical_name(self, file_path: str) -> str:
+        return "local:/" + os.path.normpath(os.path.join(self.cwd, file_path))

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -158,3 +158,6 @@ class Local(FS):
         return [
             str(item.relative_to(self.cwd))
             for item in pathlib.Path(self.cwd).glob(pattern)]
+
+    def normpath(self, file_path: str) -> str:
+        return "local" + os.path.normpath(os.path.join(self.cwd, file_path))

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -360,6 +360,16 @@ class S3(FS):
         if not _skip_connect:
             self._connect()
 
+        if self.endpoint is not None:
+            parsed = urllib.parse.urlparse(self.endpoint)
+            if parsed.scheme == "":
+                parsed = urllib.parse.urlparse(f"http://{self.endpoint}")
+            self.hostname = parsed.hostname
+        else:
+            # self.endpoint is not defined in moto3 environment
+            self.hostname = "undefined"
+            print("S3 endpoint is not defined")
+
     def _reset(self):
         self._connect()
 
@@ -608,17 +618,7 @@ class S3(FS):
                                          Key=key)
 
     def _canonical_name(self, file_path: str) -> str:
-        if self.endpoint is not None:
-            parsed = urllib.parse.urlparse(self.endpoint)
-            if parsed.scheme == "":
-                parsed = urllib.parse.urlparse(f"http://{self.endpoint}")
-            hostname = parsed.hostname
-        else:
-            # self.endpoint is not defined in moto3 environment
-            hostname = "undefined"
-            print("S3 endpoint is not defined")
-
         path = os.path.join(self.cwd, file_path)
         norm_path = _normalize_key(path)
 
-        return f"s3://{hostname}/{self.bucket}/{norm_path}"
+        return f"s3://{self.hostname}/{self.bucket}/{norm_path}"

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -605,3 +605,13 @@ class S3(FS):
         key = _normalize_key(key)
         return self.client.delete_object(Bucket=self.bucket,
                                          Key=key)
+
+    def normpath(self, file_path: str) -> str:
+        path = os.path.join(self.cwd, file_path)
+        norm_path = _normalize_key(path)
+
+        return "s3(endpoint={})/{}/{}".format(
+            self.endpoint,
+            self.bucket,
+            norm_path
+        )

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -263,6 +263,13 @@ class Zip(FS):
     def remove(self, file_path, recursive=False):
         raise io.UnsupportedOperation
 
+    def normpath(self, file_path: str) -> str:
+        file_path = os.path.join(self.cwd, os.path.normpath(file_path))
+        return "{}/zipfile/{}".format(
+            self.backend.normpath(self.file_path),
+            file_path
+        )
+
 
 def _open_zip(fs, file_path, mode, **kwargs) -> Zip:
     return Zip(fs, file_path, mode, **kwargs)

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -263,12 +263,13 @@ class Zip(FS):
     def remove(self, file_path, recursive=False):
         raise io.UnsupportedOperation
 
-    def normpath(self, file_path: str) -> str:
+    def _canonical_name(self, file_path: str) -> str:
+        canonical_name = self.backend._canonical_name(self.file_path)
         file_path = os.path.join(self.cwd, os.path.normpath(file_path))
-        return "{}/zipfile/{}".format(
-            self.backend.normpath(self.file_path),
-            file_path
-        )
+
+        # Use pfio-zipfs as reserved name to represent PFIO's Zip.
+        # If someone use `pfio-zipfs` in file_path, this might be broken.
+        return f"{canonical_name}/pfio-zipfs/{file_path}"
 
 
 def _open_zip(fs, file_path, mode, **kwargs) -> Zip:

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -204,36 +204,3 @@ def test_recreate():
     p.start()
     p.join(timeout=1)
     assert p.exitcode == 0
-
-
-def test_normpath_local():
-    with tempfile.TemporaryDirectory() as d:
-        with from_url(d) as fs:
-            filename = "somefile"
-            assert \
-                "local{}/{}".format(d, filename) == fs.normpath(filename)
-            zipfilename = "some.zip"
-            with fs.open_zip(zipfilename, mode="w") as zipfs:
-                assert \
-                    "local{}/{}/zipfile/hoge/fuga".format(
-                        d, zipfilename
-                    ) == zipfs.normpath("hoge//fuga")
-
-
-@mock_s3
-def test_normpath_s3():
-    bucket = "test-dummy-bucket"
-    with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
-        filename = "somefile"
-        assert \
-            "s3(endpoint=None)/{}/{}".format(
-                bucket,
-                filename
-            ) == fs.normpath(filename)
-        zipfilename = "some.zip"
-        with fs.open_zip(zipfilename, mode="w") as zipfs:
-            assert \
-                "s3(endpoint=None)/{}/{}/zipfile/hoge/fuga".format(
-                    bucket,
-                    zipfilename
-                ) == zipfs.normpath("hoge//fuga")

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -204,3 +204,36 @@ def test_recreate():
     p.start()
     p.join(timeout=1)
     assert p.exitcode == 0
+
+
+def test_normpath_local():
+    with tempfile.TemporaryDirectory() as d:
+        with from_url(d) as fs:
+            filename = "somefile"
+            assert \
+                "local{}/{}".format(d, filename) == fs.normpath(filename)
+            zipfilename = "some.zip"
+            with fs.open_zip(zipfilename, mode="w") as zipfs:
+                assert \
+                    "local{}/{}/zipfile/hoge/fuga".format(
+                        d, zipfilename
+                    ) == zipfs.normpath("hoge//fuga")
+
+
+@mock_s3
+def test_normpath_s3():
+    bucket = "test-dummy-bucket"
+    with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
+        filename = "somefile"
+        assert \
+            "s3(endpoint=None)/{}/{}".format(
+                bucket,
+                filename
+            ) == fs.normpath(filename)
+        zipfilename = "some.zip"
+        with fs.open_zip(zipfilename, mode="w") as zipfs:
+            assert \
+                "s3(endpoint=None)/{}/{}/zipfile/hoge/fuga".format(
+                    bucket,
+                    zipfilename
+                ) == zipfs.normpath("hoge//fuga")

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -26,6 +26,12 @@ def test_normpath_local():
                         d, zipfilename
                     ) == zipfs.normpath("hoge//fuga")
 
+            foldername = "somefolder"
+            with fs.subfs(foldername) as subfs:
+                assert \
+                    "local{}/{}/{}".format(d, foldername, filename) \
+                    == subfs.normpath(filename)
+
 
 @mock_s3
 def test_normpath_s3():
@@ -44,6 +50,15 @@ def test_normpath_s3():
                     bucket,
                     zipfilename
                 ) == zipfs.normpath("hoge//fuga")
+
+        prefixname = "someprefix"
+        with fs.subfs(prefixname) as subfs:
+            assert \
+                "s3(endpoint=None)/{}/{}/{}".format(
+                    bucket,
+                    prefixname,
+                    filename
+                ) == subfs.normpath(filename)
 
 
 @parameterized.expand(["s3", "local"])

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -1,0 +1,144 @@
+# Test HTTPCachedFS
+# TODO: test with hdfs?
+
+import io
+import tempfile
+import zipfile
+
+from moto import mock_s3
+from parameterized import parameterized
+from test_fs import gen_fs
+
+from pfio.testing import make_http_server
+from pfio.v2 import HTTPCachedFS, from_url
+
+
+def test_normpath_local():
+    with tempfile.TemporaryDirectory() as d:
+        with from_url(d) as fs:
+            filename = "somefile"
+            assert \
+                "local{}/{}".format(d, filename) == fs.normpath(filename)
+            zipfilename = "some.zip"
+            with fs.open_zip(zipfilename, mode="w") as zipfs:
+                assert \
+                    "local{}/{}/zipfile/hoge/fuga".format(
+                        d, zipfilename
+                    ) == zipfs.normpath("hoge//fuga")
+
+
+@mock_s3
+def test_normpath_s3():
+    bucket = "test-dummy-bucket"
+    with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
+        filename = "somefile"
+        assert \
+            "s3(endpoint=None)/{}/{}".format(
+                bucket,
+                filename
+            ) == fs.normpath(filename)
+        zipfilename = "some.zip"
+        with fs.open_zip(zipfilename, mode="w") as zipfs:
+            assert \
+                "s3(endpoint=None)/{}/{}/zipfile/hoge/fuga".format(
+                    bucket,
+                    zipfilename
+                ) == zipfs.normpath("hoge//fuga")
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_httpcache_simple(target):
+    filename = "testfile"
+    content = b"deadbeef"
+
+    with make_http_server() as (httpd, port):
+        http_cache = f"http://localhost:{port}/"
+        cache_content = httpd.RequestHandlerClass.files
+
+        with gen_fs(target) as underlay:
+            fs = HTTPCachedFS(http_cache, underlay)
+            with fs.open(filename, mode="wb") as fp:
+                fp.write(content)
+            with fs.open(filename, mode="rb") as fp:
+                assert fp.read(-1) == content
+            normpath = fs.normpath(filename)
+
+        assert cache_content["/" + normpath] == content
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_httpcache_zipfile_flat(target):
+    zipfilename = "test.zip"
+    filename1 = "testfile1"
+    filecontent1 = b"deadbeef"
+    filename2 = "testfile2"
+    filecontent2 = b"deadbeeeeeef"
+
+    with make_http_server() as (httpd, port):
+        http_cache = f"http://localhost:{port}/"
+        cache_content = httpd.RequestHandlerClass.files
+
+        with gen_fs(target) as underlay:
+            with underlay.open_zip(zipfilename, mode="w") as zipfs:
+                fs = HTTPCachedFS(http_cache, zipfs)
+                with fs.open(filename1, mode="wb") as fp:
+                    fp.write(filecontent1)
+                with fs.open(filename2, mode="wb") as fp:
+                    fp.write(filecontent2)
+
+                assert len(cache_content) == 0
+
+            with underlay.open_zip(zipfilename, mode="r") as zipfs:
+                fs = HTTPCachedFS(http_cache, zipfs)
+                with fs.open(filename1, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent1
+                with fs.open(filename2, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent2
+
+                assert len(cache_content) == 2
+
+        assert cache_content["/" + fs.normpath(filename1)] == filecontent1
+        assert cache_content["/" + fs.normpath(filename2)] == filecontent2
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_httpcache_zipfile_archived(target):
+    zipfilename = "test.zip"
+    filename1 = "testfile1"
+    filecontent1 = b"deadbeef"
+    filename2 = "testfile2"
+    filecontent2 = b"deadbeeeeeef"
+
+    with make_http_server() as (httpd, port):
+        http_cache = f"http://localhost:{port}/"
+        cache_content = httpd.RequestHandlerClass.files
+
+        with gen_fs(target) as underlay:
+            cached_fs = HTTPCachedFS(http_cache, underlay)
+
+            with cached_fs.open_zip(zipfilename, mode="w") as fs:
+                with fs.open(filename1, mode="wb") as fp:
+                    fp.write(filecontent1)
+                with fs.open(filename2, mode="wb") as fp:
+                    fp.write(filecontent2)
+
+                assert len(cache_content) == 0
+
+            with cached_fs.open_zip(zipfilename, mode="r") as fs:
+                with fs.open(filename1, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent1
+                with fs.open(filename2, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent2
+
+                assert len(cache_content) == 1
+
+        archive_bytes = cache_content["/" + cached_fs.normpath(zipfilename)]
+        with io.BytesIO(archive_bytes) as bytesio:
+            with zipfile.ZipFile(bytesio) as archive:
+                with archive.open(filename1) as fp:
+                    assert fp.read(-1) == filecontent1
+                with archive.open(filename2) as fp:
+                    assert fp.read(-1) == filecontent2

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -18,18 +18,18 @@ def test_normpath_local():
         with from_url(d) as fs:
             filename = "somefile"
             assert \
-                f"local:/{d}/{filename}" == fs._canonical_name(filename)
+                f"file:/{d}/{filename}" == fs._canonical_name(filename)
             zipfilename = "some.zip"
             with fs.open_zip(zipfilename, mode="w") as zipfs:
                 assert (
-                    f"local:/{d}/{zipfilename}/pfio-zipfs/hoge/fuga" ==
+                    f"file:/{d}/{zipfilename}/pfio-zipfs/hoge/fuga" ==
                     zipfs._canonical_name("hoge//fuga")
                 )
 
             foldername = "somefolder"
             with fs.subfs(foldername) as subfs:
                 assert (
-                    f"local:/{d}/{foldername}/{filename}" ==
+                    f"file:/{d}/{foldername}/{filename}" ==
                     subfs._canonical_name(filename)
                 )
 


### PR DESCRIPTION
This PR adds HTTPCachedFS, a wrapper to hook read operations and cache the content with HTTPConnector. HTTPCachedFS wrapper hooks read operations, then try HTTPCache to retrieve its content. The underlying FS will not be called if the data is in the cache. Other operations like write and list will be transferred to the underlying FS.

In order to introduce such a feature, I added `_canonical_name(path)` to FS interface and implementations. `_canonical_name(path)` returns `path` with filesystem information to distinguish Local("abc")._canonical_name("somefile") and S3("abc")._canonical_name("somefile"). S3 and HDFS will encode its endpoint to the path to distinguish multiple endpoints (like AWS's S3 and some S3 compatible storage systems).

Users can enable HTTPCache transparently by following methods:
- Give `http_cache="http://cache-service/"` to `pfio.v2.from_url` method. `from_url` automatically wraps `pfio.v2.FS` to hook all read operations. This will work with local, s3, and zipfs.
  - In the zipfs case, the data in zipfs will be stored in the cache system in a flat manner. It means the url of `somefile` in `hoge.zip` will be `http://{given_url}/hoge.zip/zipfile/somefile`. 
- Or, users can instantiate `HTTPCachedFS` directly