### PR TITLE
Faster HTTPConnector

### DIFF
--- a/pfio/cache/http_cache.py
+++ b/pfio/cache/http_cache.py
@@ -1,11 +1,12 @@
+import collections
+import contextlib
+import http.client
 import logging
 import os
 import pickle
 import time
-from typing import Any, Optional
-
-import urllib3
-import urllib3.exceptions
+import urllib.parse
+from typing import Any, Dict, Generator, List, Optional
 
 from pfio.cache import Cache
 
@@ -14,16 +15,16 @@ logger.addHandler(logging.StreamHandler())
 
 
 class _ConnectionPool(object):
-    def __init__(self, retries: int, timeout: int):
-        self.retries = retries
+    def __init__(self, timeout: int):
         self.timeout = timeout
-
-        self.conn: Optional[urllib3.poolmanager.PoolManager] = None
-        self.pid: Optional[int] = None
+        self.conn: \
+            Dict[str, List[http.client.HTTPConnection]] = \
+            collections.defaultdict(list)
+        self.pid = os.getpid()
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state['conn'] = None
+        state['conn'] = collections.defaultdict(list)
         return state
 
     def __setstate__(self, state):
@@ -33,23 +34,37 @@ class _ConnectionPool(object):
     def is_forked(self):
         return self.pid != os.getpid()
 
-    def urlopen(self, method, url, redirect=True, **kw):
-        if self.is_forked or self.conn is None:
-            self.conn = urllib3.poolmanager.PoolManager(
-                retries=self.retries,
-                timeout=self.timeout
-            )
-            self.pid = os.getpid()
-        return self.conn.urlopen(method, url, redirect, **kw)
+    @contextlib.contextmanager
+    def get(self, host: str) -> \
+            Generator[http.client.HTTPConnection, None, None]:
+        if self.is_forked:
+            self.conn = collections.defaultdict(list)
+
+        conn: http.client.HTTPConnection
+        try:
+            conn = self.conn[host].pop()
+        except (IndexError, AssertionError):
+            conn = self._new_connection(host)
+
+        try:
+            yield conn
+        finally:
+            self.conn[host].append(conn)
+
+    def _new_connection(self, host: str) -> http.client.HTTPConnection:
+        return http.client.HTTPConnection(
+            host,
+            timeout=self.timeout
+        )
 
 
 CONNECTION_POOL: Optional[_ConnectionPool] = None
 
 
-def _get_connection_pool(retries: int, timeout: int) -> _ConnectionPool:
+def _get_connection_pool(timeout: int) -> _ConnectionPool:
     global CONNECTION_POOL
     if CONNECTION_POOL is None:
-        CONNECTION_POOL = _ConnectionPool(retries, timeout)
+        CONNECTION_POOL = _ConnectionPool(timeout)
     return CONNECTION_POOL
 
 
@@ -57,12 +72,28 @@ class HTTPConnector(object):
     def __init__(self,
                  url: str,
                  bearer_token_path: Optional[str] = None,
-                 retries: int = 1,
                  timeout: int = 3):
-        if url.endswith("/"):
-            self.url = url
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme == "":
+            url = "http://" + url
+            parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "http":
+            raise ValueError("HTTPConnector: url should start with http://")
+        if (
+            parsed.params != "" or
+            parsed.query != "" or
+            parsed.fragment != "" or
+            parsed.username is not None or
+            parsed.password is not None
+        ):
+            raise ValueError("HTTPConnector: unexpected url {}".format(parsed))
+
+        self.host = parsed.netloc
+        if parsed.path.endswith("/"):
+            self.path = parsed.path
         else:
-            self.url = url + "/"
+            self.path = parsed.path + "/"
+        self.conn = _get_connection_pool(timeout)
 
         self.bearer_token_path: Optional[str] = None
         if bearer_token_path is not None:
@@ -73,41 +104,57 @@ class HTTPConnector(object):
         if self.bearer_token_path is not None:
             self._token_read_now()
 
-        # Allow redirect or retry once by default
-        self.conn = _get_connection_pool(retries, timeout)
-
     def put(self, suffix: str, data: bytes) -> bool:
-        try:
-            res = self.conn.urlopen("PUT",
-                                    url=self.url + suffix,
-                                    headers=self._header_with_token(),
-                                    body=data)
-        except urllib3.exceptions.RequestError as e:
-            logger.warning("put: {}".format(e))
-            return False
+        conn: http.client.HTTPConnection
+        with self.conn.get(self.host) as conn:
+            try:
+                conn.request(
+                    "PUT",
+                    url=self.path + suffix,
+                    body=data,
+                    headers=self._header_with_token()
+                )
+                res = conn.getresponse()
+                res.read()
 
-        if res.status == 201:
-            return True
-        else:
-            logger.warning("put: unexpected status code {}".format(res.status))
-            return False
+                if res.status == 201:
+                    return True
+                else:
+                    logger.warning(
+                        "put: unexpected status code {}".format(res.status)
+                    )
+                    return False
+
+            except (http.client.HTTPException, OSError) as e:
+                logger.warning("put: {} {}".format(e, type(e)))
+                conn.close()  # fix error state
+                return False
 
     def get(self, suffix: str) -> Optional[bytes]:
-        try:
-            res = self.conn.urlopen("GET",
-                                    url=self.url + suffix,
-                                    headers=self._header_with_token())
-        except urllib3.exceptions.RequestError as e:
-            logger.warning("get: {}".format(e))
-            return None
+        conn: http.client.HTTPConnection
+        with self.conn.get(self.host) as conn:
+            try:
+                conn.request(
+                    "GET",
+                    url=self.path + suffix,
+                    headers=self._header_with_token()
+                )
+                res = conn.getresponse()
+                data = res.read()
 
-        if res.status == 200:
-            return res.data
-        elif res.status == 404:
-            return None
-        else:
-            logger.warning("get: unexpected status code {}".format(res.status))
-            return None
+                if res.status == 200:
+                    return data
+                elif res.status == 404:
+                    return None
+                else:
+                    logger.warning(
+                        "get: unexpected status code {}".format(res.status)
+                    )
+                    return None
+            except (http.client.HTTPException, OSError) as e:
+                logger.warning("get: {} {}".format(e, type(e)))
+                conn.close()  # fix error state
+                return None
 
     def _header_with_token(self) -> dict:
         if self.bearer_token_path is None:

--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -29,6 +29,7 @@ Or::
 '''
 from .fs import from_url, lazify, open_url  # NOQA
 from .hdfs import Hdfs, HdfsFileStat  # NOQA
+from .http_cache import HTTPCachedFS  # NOQA
 from .local import Local, LocalFileStat  # NOQA
 from .pathlib import Path  # NOQA
 from .s3 import S3  # NOQA

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -315,7 +315,7 @@ def open_url(url: str, mode: str = 'r', **kwargs) -> Iterator[IOBase]:
        with open_url("s3://bucket.example.com/path/your-file.txt", 'r') as f:
            f.read()
 
-    .. note:: Some FS resouces won't be closed when using this
+    .. note:: Some FS resources won't be closed when using this
         functionality. See ``from_url`` for keyword arguments.
 
     Returns:
@@ -351,7 +351,11 @@ def from_url(url: str, **kwargs) -> 'FS':
 
         create (bool): Create the specified path doesn't exist.
 
-    .. note:: Some FS resouces won't be closed when using this
+        http_cache (str): Prefix url of http cached entries.
+            For details, please refer to ``HTTPCachedFS``.
+            (experimental feature)
+
+    .. note:: Some FS resources won't be closed when using this
         functionality.
 
     .. note:: Pickling the FS object may or may not work correctly
@@ -376,6 +380,8 @@ def from_url(url: str, **kwargs) -> 'FS':
     if force_type is not None and force_type != "zip":
         if force_type != scheme:
             raise ValueError("URL scheme mismatch with forced type")
+
+    http_cache_prefix = kwargs.pop("http_cache", None)
 
     def _zip_check_create_not_supported():
         if kwargs.get('create', False):
@@ -406,6 +412,10 @@ def from_url(url: str, **kwargs) -> 'FS':
     else:
         dirname = parsed.path
         fs = _from_scheme(scheme, dirname, kwargs, bucket=parsed.netloc)
+
+    if http_cache_prefix is not None:
+        from .http_cache import HTTPCachedFS
+        fs = HTTPCachedFS(http_cache_prefix, fs)
 
     return fs
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -297,6 +297,12 @@ class FS(abc.ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def normpath(self, file_path: str) -> str:
+        """Returns its normpath with protocol and endpoint
+        """
+        raise NotImplementedError
+
 
 @contextlib.contextmanager
 def open_url(url: str, mode: str = 'r', **kwargs) -> Iterator[IOBase]:

--- a/pfio/v2/http_cache.py
+++ b/pfio/v2/http_cache.py
@@ -1,0 +1,224 @@
+import io
+from types import TracebackType
+from typing import Any, Iterator, Optional, Type, Union
+
+from pfio.cache import HTTPConnector
+
+from .fs import FS, FileStat
+
+
+class HTTPCachedFS(FS):
+    """HTTP-based cache system
+
+    Stores cache data in an HTTP server with ``PUT`` and ``GET`` methods. Each
+    cache entry corresponds to url suffixed by normalized paths (``normpath``).
+
+    Arguments:
+        url (string):
+            Prefix url of cache entries. Each entry corresponds to the url
+            suffixed by each normalized paths.
+
+        fs (pfio.v2.FS):
+            Underlying filesystem.
+
+            Read operations will be hooked by HTTPCachedFS to send a request to
+            the cache system. If the object is found in cache, the object will
+            be returned from cache without requesting to underlying fs.
+            Therefore, after the update of file in underlying fs, users have to
+            update url to avoid reading old data from the cache.
+
+            Other operations including write will not be hooked. It will be
+            transferred to underlying filesystem immediately.
+
+        bearer_token_path (string):
+            Path to HTTP bearer token if authorization required.
+            ``HTTPCachedFS`` supports refresh of bearer token by periodical
+            reloading.
+
+    .. note:: This feature is experimental.
+
+    """
+
+    def __init__(self,
+                 url: str,
+                 fs: FS,
+                 bearer_token_path: Optional[str] = None):
+        super().__init__()
+        self.fs = fs
+        self.conn = HTTPConnector(url, bearer_token_path)
+        if url.endswith("/"):
+            self.url = url
+        else:
+            self.url = url + "/"
+
+    def open(self,
+             file_path: str,
+             mode: str = 'rb',
+             *args, **kwargs) -> io.IOBase:
+        if 'r' in mode:
+            kwargs['mode'] = mode
+            return _HTTPCacheIOBase(file_path, self.conn, self.fs,
+                                    args, kwargs)
+        else:
+            return self.fs.open(file_path, mode, *args, **kwargs)
+
+    def _reset(self):
+        self.fs._reset()
+
+    def list(self, *args, **kwargs) -> Iterator[Union[FileStat, str]]:
+        return self.fs.list(*args, **kwargs)
+
+    def stat(self, *args, **kwargs) -> FileStat:
+        return self.fs.stat(*args, **kwargs)
+
+    def isdir(self, *args, **kwargs) -> bool:
+        return self.fs.isdir(*args, **kwargs)
+
+    def mkdir(self, *args, **kwargs) -> None:
+        return self.fs.mkdir(*args, **kwargs)
+
+    def makedirs(self, *args, **kwargs) -> None:
+        return self.fs.makedirs(*args, **kwargs)
+
+    def exists(self, *args, **kwargs) -> bool:
+        return self.fs.exists(*args, **kwargs)
+
+    def rename(self, *args, **kwargs) -> None:
+        return self.fs.rename(*args, **kwargs)
+
+    def remove(self, *args, **kwargs) -> None:
+        return self.fs.remove(*args, **kwargs)
+
+    def glob(self, pattern: str) -> Iterator[Union[FileStat, str]]:
+        return self.fs.glob(pattern)
+
+    def normpath(self, file_path: str) -> str:
+        # Don't add httpcache in normpath
+        return self.fs.normpath(file_path)
+
+
+class _HTTPCacheIOBase(io.RawIOBase):
+    def __init__(self,
+                 file_path: str,
+                 conn: HTTPConnector,
+                 fs: FS,
+                 open_args: Any, open_kwargs: dict):
+        super(_HTTPCacheIOBase, self).__init__()
+
+        self.file_path = file_path
+        self.conn = conn
+        self.fs = fs
+        self.open_args = open_args
+        self.open_kwargs = open_kwargs
+
+        self.cache_path = self.fs.normpath(self.file_path)
+        self.whole_file: Optional[bytes] = None
+        self.pos = 0
+        self._closed = False
+
+    def _load_file(self):
+        if self.whole_file is not None:
+            return
+
+        data = self.conn.get(self.cache_path)
+        if data is not None:
+            self.whole_file = data
+            return
+
+        with self.fs.open(self.file_path,
+                          *self.open_args, **self.open_kwargs) as f:
+            self.whole_file = f.read(-1)
+
+        if 1024 * 1024 * 1024 <= len(self.whole_file):
+            print(
+                "HTTPCachedFS: Too big data ({} bytes)".format(
+                    len(self.whole_file)
+                )
+            )
+            return
+
+        self.conn.put(self.cache_path, self.whole_file)
+
+    def read(self, size=-1) -> bytes:
+        self._load_file()
+        if self.whole_file is None:
+            print("HTTPCachedFS: failed to read from backend fs")
+            return b''
+
+        if len(self.whole_file) <= self.pos:
+            return b''
+        elif size <= 0:
+            data = self.whole_file[self.pos:]
+        else:
+            end = min(self.pos + size, len(self.whole_file))
+            data = self.whole_file[self.pos:end]
+
+        self.pos += len(data)
+        return data
+
+    def readline(self):
+        raise NotImplementedError()
+
+    def close(self):
+        self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]):
+        self.close()
+
+    def flush(self):
+        pass
+
+    @property
+    def closed(self):
+        return self._closed
+
+    def isatty(self):
+        return False
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def tell(self):
+        return self.pos
+
+    def truncate(self, size=None):
+        raise io.UnsupportedOperation('truncate')
+
+    def seek(self, pos, whence=io.SEEK_SET):
+        if whence in [0, io.SEEK_SET]:
+            if pos < 0:
+                raise OSError(22, "[Errno 22] Invalid argument")
+        elif whence in [1, io.SEEK_CUR]:
+            pos += self.pos
+        elif whence in [2, io.SEEK_END]:
+            self._load_file()
+            pos += len(self.whole_file)
+        else:
+            raise ValueError('Wrong whence value: {}'.format(whence))
+
+        if pos < 0:
+            raise OSError(22, "[Errno 22] Invalid argument")
+        self.pos = pos
+        return self.pos
+
+    def writable(self):
+        return False
+
+    def write(self, data):
+        raise io.UnsupportedOperation('not writable')
+
+    def readall(self):
+        return self.read(-1)
+
+    def readinto(self, b):
+        buf = self.read(len(b))
+        b[:len(buf)] = buf
+        return len(buf)

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -158,3 +158,6 @@ class Local(FS):
         return [
             str(item.relative_to(self.cwd))
             for item in pathlib.Path(self.cwd).glob(pattern)]
+
+    def normpath(self, file_path: str) -> str:
+        return "local" + os.path.normpath(os.path.join(self.cwd, file_path))

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -605,3 +605,13 @@ class S3(FS):
         key = _normalize_key(key)
         return self.client.delete_object(Bucket=self.bucket,
                                          Key=key)
+
+    def normpath(self, file_path: str) -> str:
+        path = os.path.join(self.cwd, file_path)
+        norm_path = _normalize_key(path)
+
+        return "s3(endpoint={})/{}/{}".format(
+            self.endpoint,
+            self.bucket,
+            norm_path
+        )

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -263,6 +263,13 @@ class Zip(FS):
     def remove(self, file_path, recursive=False):
         raise io.UnsupportedOperation
 
+    def normpath(self, file_path: str) -> str:
+        file_path = os.path.join(self.cwd, os.path.normpath(file_path))
+        return "{}/zipfile/{}".format(
+            self.backend.normpath(self.file_path),
+            file_path
+        )
+
 
 def _open_zip(fs, file_path, mode, **kwargs) -> Zip:
     return Zip(fs, file_path, mode, **kwargs)

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -204,36 +204,3 @@ def test_recreate():
     p.start()
     p.join(timeout=1)
     assert p.exitcode == 0
-
-
-def test_normpath_local():
-    with tempfile.TemporaryDirectory() as d:
-        with from_url(d) as fs:
-            filename = "somefile"
-            assert \
-                "local{}/{}".format(d, filename) == fs.normpath(filename)
-            zipfilename = "some.zip"
-            with fs.open_zip(zipfilename, mode="w") as zipfs:
-                assert \
-                    "local{}/{}/zipfile/hoge/fuga".format(
-                        d, zipfilename
-                    ) == zipfs.normpath("hoge//fuga")
-
-
-@mock_s3
-def test_normpath_s3():
-    bucket = "test-dummy-bucket"
-    with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
-        filename = "somefile"
-        assert \
-            "s3(endpoint=None)/{}/{}".format(
-                bucket,
-                filename
-            ) == fs.normpath(filename)
-        zipfilename = "some.zip"
-        with fs.open_zip(zipfilename, mode="w") as zipfs:
-            assert \
-                "s3(endpoint=None)/{}/{}/zipfile/hoge/fuga".format(
-                    bucket,
-                    zipfilename
-                ) == zipfs.normpath("hoge//fuga")

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -204,3 +204,36 @@ def test_recreate():
     p.start()
     p.join(timeout=1)
     assert p.exitcode == 0
+
+
+def test_normpath_local():
+    with tempfile.TemporaryDirectory() as d:
+        with from_url(d) as fs:
+            filename = "somefile"
+            assert \
+                "local{}/{}".format(d, filename) == fs.normpath(filename)
+            zipfilename = "some.zip"
+            with fs.open_zip(zipfilename, mode="w") as zipfs:
+                assert \
+                    "local{}/{}/zipfile/hoge/fuga".format(
+                        d, zipfilename
+                    ) == zipfs.normpath("hoge//fuga")
+
+
+@mock_s3
+def test_normpath_s3():
+    bucket = "test-dummy-bucket"
+    with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
+        filename = "somefile"
+        assert \
+            "s3(endpoint=None)/{}/{}".format(
+                bucket,
+                filename
+            ) == fs.normpath(filename)
+        zipfilename = "some.zip"
+        with fs.open_zip(zipfilename, mode="w") as zipfs:
+            assert \
+                "s3(endpoint=None)/{}/{}/zipfile/hoge/fuga".format(
+                    bucket,
+                    zipfilename
+                ) == zipfs.normpath("hoge//fuga")

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -26,6 +26,12 @@ def test_normpath_local():
                         d, zipfilename
                     ) == zipfs.normpath("hoge//fuga")
 
+            foldername = "somefolder"
+            with fs.subfs(foldername) as subfs:
+                assert \
+                    "local{}/{}/{}".format(d, foldername, filename) \
+                    == subfs.normpath(filename)
+
 
 @mock_s3
 def test_normpath_s3():
@@ -44,6 +50,15 @@ def test_normpath_s3():
                     bucket,
                     zipfilename
                 ) == zipfs.normpath("hoge//fuga")
+
+        prefixname = "someprefix"
+        with fs.subfs(prefixname) as subfs:
+            assert \
+                "s3(endpoint=None)/{}/{}/{}".format(
+                    bucket,
+                    prefixname,
+                    filename
+                ) == subfs.normpath(filename)
 
 
 @parameterized.expand(["s3", "local"])

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -1,0 +1,144 @@
+# Test HTTPCachedFS
+# TODO: test with hdfs?
+
+import io
+import tempfile
+import zipfile
+
+from moto import mock_s3
+from parameterized import parameterized
+from test_fs import gen_fs
+
+from pfio.testing import make_http_server
+from pfio.v2 import HTTPCachedFS, from_url
+
+
+def test_normpath_local():
+    with tempfile.TemporaryDirectory() as d:
+        with from_url(d) as fs:
+            filename = "somefile"
+            assert \
+                "local{}/{}".format(d, filename) == fs.normpath(filename)
+            zipfilename = "some.zip"
+            with fs.open_zip(zipfilename, mode="w") as zipfs:
+                assert \
+                    "local{}/{}/zipfile/hoge/fuga".format(
+                        d, zipfilename
+                    ) == zipfs.normpath("hoge//fuga")
+
+
+@mock_s3
+def test_normpath_s3():
+    bucket = "test-dummy-bucket"
+    with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
+        filename = "somefile"
+        assert \
+            "s3(endpoint=None)/{}/{}".format(
+                bucket,
+                filename
+            ) == fs.normpath(filename)
+        zipfilename = "some.zip"
+        with fs.open_zip(zipfilename, mode="w") as zipfs:
+            assert \
+                "s3(endpoint=None)/{}/{}/zipfile/hoge/fuga".format(
+                    bucket,
+                    zipfilename
+                ) == zipfs.normpath("hoge//fuga")
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_httpcache_simple(target):
+    filename = "testfile"
+    content = b"deadbeef"
+
+    with make_http_server() as (httpd, port):
+        http_cache = f"http://localhost:{port}/"
+        cache_content = httpd.RequestHandlerClass.files
+
+        with gen_fs(target) as underlay:
+            fs = HTTPCachedFS(http_cache, underlay)
+            with fs.open(filename, mode="wb") as fp:
+                fp.write(content)
+            with fs.open(filename, mode="rb") as fp:
+                assert fp.read(-1) == content
+            normpath = fs.normpath(filename)
+
+        assert cache_content["/" + normpath] == content
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_httpcache_zipfile_flat(target):
+    zipfilename = "test.zip"
+    filename1 = "testfile1"
+    filecontent1 = b"deadbeef"
+    filename2 = "testfile2"
+    filecontent2 = b"deadbeeeeeef"
+
+    with make_http_server() as (httpd, port):
+        http_cache = f"http://localhost:{port}/"
+        cache_content = httpd.RequestHandlerClass.files
+
+        with gen_fs(target) as underlay:
+            with underlay.open_zip(zipfilename, mode="w") as zipfs:
+                fs = HTTPCachedFS(http_cache, zipfs)
+                with fs.open(filename1, mode="wb") as fp:
+                    fp.write(filecontent1)
+                with fs.open(filename2, mode="wb") as fp:
+                    fp.write(filecontent2)
+
+                assert len(cache_content) == 0
+
+            with underlay.open_zip(zipfilename, mode="r") as zipfs:
+                fs = HTTPCachedFS(http_cache, zipfs)
+                with fs.open(filename1, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent1
+                with fs.open(filename2, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent2
+
+                assert len(cache_content) == 2
+
+        assert cache_content["/" + fs.normpath(filename1)] == filecontent1
+        assert cache_content["/" + fs.normpath(filename2)] == filecontent2
+
+
+@parameterized.expand(["s3", "local"])
+@mock_s3
+def test_httpcache_zipfile_archived(target):
+    zipfilename = "test.zip"
+    filename1 = "testfile1"
+    filecontent1 = b"deadbeef"
+    filename2 = "testfile2"
+    filecontent2 = b"deadbeeeeeef"
+
+    with make_http_server() as (httpd, port):
+        http_cache = f"http://localhost:{port}/"
+        cache_content = httpd.RequestHandlerClass.files
+
+        with gen_fs(target) as underlay:
+            cached_fs = HTTPCachedFS(http_cache, underlay)
+
+            with cached_fs.open_zip(zipfilename, mode="w") as fs:
+                with fs.open(filename1, mode="wb") as fp:
+                    fp.write(filecontent1)
+                with fs.open(filename2, mode="wb") as fp:
+                    fp.write(filecontent2)
+
+                assert len(cache_content) == 0
+
+            with cached_fs.open_zip(zipfilename, mode="r") as fs:
+                with fs.open(filename1, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent1
+                with fs.open(filename2, mode="rb") as fp:
+                    assert fp.read(-1) == filecontent2
+
+                assert len(cache_content) == 1
+
+        archive_bytes = cache_content["/" + cached_fs.normpath(zipfilename)]
+        with io.BytesIO(archive_bytes) as bytesio:
+            with zipfile.ZipFile(bytesio) as archive:
+                with archive.open(filename1) as fp:
+                    assert fp.read(-1) == filecontent1
+                with archive.open(filename2) as fp:
+                    assert fp.read(-1) == filecontent2


### PR DESCRIPTION
I profiled HTTPConnector's performance by using [cProfile](https://docs.python.org/3/library/profile.html) and [snakeviz](https://jiffyclub.github.io/snakeviz/). I found that urllib3's HTTP request is not optimized for sending requests to the same host.

Previous: 
<img width="1483" alt="image" src="https://github.com/pfnet/pfio/assets/4938419/20079c72-7127-4c6a-9028-0e4e0e4ffbda">
The given url is parsed many times to get appropriate connection from the connection pool. The url parse is actually just execution of regexp, but from the perspective of small file use case (latency-neck), it should not be happened many times.

This PR:
<img width="1488" alt="image" src="https://github.com/pfnet/pfio/assets/4938419/c2041204-d66c-4cfd-bceb-faf93c40ab98">
I re-implemented connection pool for sending requests to the same host. By this, we can see the performance improvement (we're using more time in `recvinto` relatively, so it means the latency is reduced). Also, we don't have to use urllib3 anymore.

Note: I don't implement clean up of connection pool, but if user don't use many hosts to request, it will not be a problem.