### PR TITLE
Fix flake8 v6.1.0

### DIFF
--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -84,7 +84,7 @@ def test_smoke(target):
         assert len(content) == st.size
         assert st.filename is not None
         assert st.last_modified is not None
-        assert type(st.last_modified) == float
+        assert isinstance(st.last_modified, float)
 
         with fs.open(filename2, 'wb') as fp:
             fp.write(content.encode())

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -26,7 +26,7 @@ def test_s3_zip(local_cache):
         with from_url('s3://{}/'.format(bucket),
                       create_bucket=True) as s3:
             assert isinstance(s3, S3)
-            with open(zipfilename, 'rb') as src,\
+            with open(zipfilename, 'rb') as src, \
                     s3.open('test.zip', 'wb') as dst:
                 shutil.copyfileobj(src, dst)
 
@@ -157,7 +157,7 @@ def test_force_type2():
         with from_url('s3://{}/'.format(bucket),
                       create_bucket=True) as s3:
             assert isinstance(s3, S3)
-            with open(zipfilename, 'rb') as src,\
+            with open(zipfilename, 'rb') as src, \
                     s3.open('test.zip', 'wb') as dst:
                 shutil.copyfileobj(src, dst)
 


### PR DESCRIPTION
Current master branch doesn't pass the flake8 test due to its automatic update. This PR fixes code to pass flake8 v6.1.0 test.

```
$ flake8 pfio tests                                                                                                                             
tests/v2_tests/test_fs.py:87:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`                                                                         
tests/v2_tests/test_s3_zip.py:29:48: E231 missing whitespace after ','                                                                                                                                           
tests/v2_tests/test_s3_zip.py:160:48: E231 missing whitespace after ','  
```