### PR TITLE
Add function interface to add custom scheme

### DIFF
--- a/pfio/v2/__init__.py
+++ b/pfio/v2/__init__.py
@@ -27,6 +27,7 @@ Or::
   pfio = Hdfs()
 
 '''
+from . import config  # NOQA
 from .fs import from_url, lazify, open_url  # NOQA
 from .hdfs import Hdfs, HdfsFileStat  # NOQA
 from .local import Local, LocalFileStat  # NOQA

--- a/pfio/v2/config.py
+++ b/pfio/v2/config.py
@@ -1,0 +1,46 @@
+import configparser
+import os
+from typing import Dict, Optional
+
+
+def _default_config_file():
+    path = os.getenv('PFIO_CONFIG_PATH')
+    if path:
+        return path
+
+    basedir = os.getenv('XDG_CONFIG_HOME')
+    if not basedir:
+        basedir = os.path.join(os.getenv('HOME'), ".config")
+
+    return os.path.join(basedir, "pfio.ini")
+
+
+def _reload_config():
+    global _config
+    config = configparser.ConfigParser()
+    configfile = _default_config_file()
+    config.read(configfile)
+    _config = config
+
+
+def add_custom_scheme(name: str, scheme: str, data: Optional[Dict[str, str]] = None):
+    if data is None:
+        data = {}
+    else:
+        data = data.copy()
+
+    data["scheme"] = scheme
+    _config[name] = data
+
+
+def get_custom_scheme(name: str) -> Optional[Dict[str, str]]:
+    try:
+        return dict(_config[name])
+    except KeyError:
+        return None
+
+
+_config = None
+
+
+_reload_config()

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -1,5 +1,4 @@
 import abc
-import configparser
 import contextlib
 import copy
 import os
@@ -13,6 +12,7 @@ from urllib.parse import urlparse
 
 from deprecation import deprecated
 
+from pfio.v2 import config
 from pfio.version import __version__  # NOQA
 
 
@@ -404,44 +404,13 @@ def from_url(url: str, **kwargs) -> 'FS':
     return fs
 
 
-def _default_config_file():
-    path = os.getenv('PFIO_CONFIG_PATH')
-    if path:
-        return path
-
-    basedir = os.getenv('XDG_CONFIG_HOME')
-    if not basedir:
-        basedir = os.path.join(os.getenv('HOME'), ".config")
-
-    return os.path.join(basedir, "pfio.ini")
-
-
-class _CustomScheme:
-    conf = None
-
-    @staticmethod
-    def config(scheme):
-        if _CustomScheme.conf is None:
-            _CustomScheme.load_config()
-
-        if scheme in _CustomScheme.conf:
-            return dict(_CustomScheme.conf[scheme])
-
-    @staticmethod
-    def load_config():
-        config = configparser.ConfigParser()
-        configfile = _default_config_file()
-        config.read(configfile)
-        _CustomScheme.conf = config
-
-
 def _from_scheme(scheme, dirname, kwargs, bucket=None):
     known_scheme = ['file', 'hdfs', 's3']
 
     # Custom scheme; using configparser for older Python. Will
     # update to toml in Python 3.11 once 3.10 is in the end.
     if scheme not in known_scheme:
-        config_dict = _CustomScheme.config(scheme)
+        config_dict = config.get_custom_scheme(scheme)
         if config_dict is not None:
             scheme = config_dict.pop('scheme')  # Get the real scheme
             # Custom scheme expected here
@@ -462,7 +431,7 @@ def _from_scheme(scheme, dirname, kwargs, bucket=None):
         from .s3 import S3
         fs = S3(bucket=bucket, prefix=dirname, **kwargs)
     else:
-        raise RuntimeError("bug: scheme '{}' is not supported".format(scheme))
+        raise RuntimeError("scheme '{}' is not supported".format(scheme))
 
     return fs
 

--- a/tests/v2_tests/test_custom_scheme.py
+++ b/tests/v2_tests/test_custom_scheme.py
@@ -6,10 +6,12 @@ import pfio
 
 
 @mock_s3
-def test_smoke():
+def test_ini():
     try:
         prev = os.getenv('PFIO_CONFIG_PATH')
         os.environ['PFIO_CONFIG_PATH'] = './example.pfio.ini'
+
+        pfio.v2.config._reload_config()
 
         with pfio.v2.from_url('foobar://pfio/') as fs:
             assert isinstance(fs, pfio.v2.Local)
@@ -27,3 +29,37 @@ def test_smoke():
         else:
             del os.environ['PFIO_CONFIG_PATH']
             assert not os.getenv('PFIO_CONFIG_PATH')
+
+
+@mock_s3
+def test_add_custom_scheme():
+    pfio.v2.config._reload_config()
+
+    pfio.v2.config.add_custom_scheme("foobar2", "file")
+    pfio.v2.config.add_custom_scheme(
+        "baz2",
+        "s3",
+        {
+            "endpoint": "https://s3.example.com",
+            "aws_access_key_id": "hoge",
+            "aws_secret_access_key": os.environ["HOME"]
+        },
+    )
+
+    assert {"scheme": "file"} == pfio.v2.config.get_custom_scheme("foobar2")
+    assert {
+        "scheme": "s3",
+        "endpoint": "https://s3.example.com",
+        "aws_access_key_id": "hoge",
+        "aws_secret_access_key": os.environ["HOME"],
+    } == pfio.v2.config.get_custom_scheme("baz2")
+
+    with pfio.v2.from_url('foobar2://pfio/') as fs:
+        assert isinstance(fs, pfio.v2.Local)
+
+    with pfio.v2.from_url('baz2://pfio/', _skip_connect=True) as s3:
+        assert isinstance(s3, pfio.v2.S3)
+
+        assert 'https://s3.example.com' == s3.kwargs['endpoint_url']
+        assert 'hoge' == s3.kwargs['aws_access_key_id']
+        assert os.getenv('HOME') == s3.kwargs['aws_secret_access_key']


### PR DESCRIPTION
pfio has the ability to configure additional custom schemes via an ini file (https://pfio.readthedocs.io/en/latest/design.html#custom-scheme). However, there are cases where we prefer not to rely on the environment and instead configure custom schemes explicitly.

`pfio.v2.config.add_custom_scheme()` in this PR would allow programs to configure custom schemes prior to using other pfio features without relying on an environment file.