### PR TITLE
Avoid calling zip.namelist many times

### DIFF
--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -132,10 +132,14 @@ class TestZip(unittest.TestCase):
         with local.open_zip(os.path.abspath(self.zip_file_path), 'w') as z:
             with z.open(testfile_name, "wb") as zipped_file:
                 zipped_file.write(test_string_b)
+            stat = z.stat(testfile_name)
+            assert stat.size == len(test_string_b)
 
         with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
             with z.open(testfile_name, "rb") as zipped_file:
                 self.assertEqual(test_string_b, zipped_file.readline())
+            stat = z.stat(testfile_name)
+            assert stat.size == len(test_string_b)
 
     def test_write_string(self):
         testfile_name = "testfile3"


### PR DESCRIPTION
When I tested https://github.com/pfnet/pfio/pull/316 PR with the ImageNet-1K dataset, I found that Zip(FS).stat() performance is pretty bad
because:
- list all filenames in the zip archive twice in the worst case
- check filename is correct or not by linear search twice in the worst case

Therefore, I'd like to cache filenames with the `set` structure to avoid redundant construction and improve search performance if the archive is opened in read-only mode.