### PR TITLE
Add __repr__ to FS classes

### DIFF
--- a/pfio/v2/_utils.py
+++ b/pfio/v2/_utils.py
@@ -1,0 +1,6 @@
+from typing import Any, Dict, Type
+
+
+def format_repr(cls: Type, data: Dict[str, Any]) -> str:
+    data_str = ", ".join(f"{name}={value!r}" for name, value in data.items())
+    return f"{cls.__module__}.{cls.__name__}({data_str})"

--- a/pfio/v2/_utils.py
+++ b/pfio/v2/_utils.py
@@ -1,6 +1,0 @@
-from typing import Any, Dict, Type
-
-
-def format_repr(cls: Type, data: Dict[str, Any]) -> str:
-    data_str = ", ".join(f"{name}={value!r}" for name, value in data.items())
-    return f"{cls.__module__}.{cls.__name__}({data_str})"

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -8,7 +8,7 @@ import warnings
 from abc import abstractmethod
 from io import IOBase
 from types import TracebackType
-from typing import Any, Callable, Iterator, Optional, Type, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Type, Union
 from urllib.parse import urlparse
 
 from deprecation import deprecated
@@ -474,3 +474,8 @@ def lazify(init_func, lazy_init=True, recreate_on_fork=True):
 
     '''
     pass
+
+
+def format_repr(cls: Type, data: Dict[str, Any]) -> str:
+    data_str = ", ".join(f"{name}={value!r}" for name, value in data.items())
+    return f"{cls.__module__}.{cls.__name__}({data_str})"

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -16,8 +16,7 @@ try:
 except ImportError:
     has_hdfs = False
 
-from . import _utils
-from .fs import FS, FileStat, ForkedError
+from .fs import FS, FileStat, ForkedError, format_repr
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -261,7 +260,7 @@ class Hdfs(FS):
         self.__dict__ = state
 
     def __repr__(self):
-        return _utils.format_repr(
+        return format_repr(
             Hdfs,
             {
                 "cwd": self._cwd,

--- a/pfio/v2/hdfs.py
+++ b/pfio/v2/hdfs.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     has_hdfs = False
 
+from . import _utils
 from .fs import FS, FileStat, ForkedError
 
 logger = logging.getLogger(__name__)
@@ -258,6 +259,14 @@ class Hdfs(FS):
 
     def __setstate__(self, state):
         self.__dict__ = state
+
+    def __repr__(self):
+        return _utils.format_repr(
+            Hdfs,
+            {
+                "cwd": self._cwd,
+            },
+        )
 
     def _get_principal_name(self):
         # get the default principal name from `klist` cache

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -4,6 +4,7 @@ import pathlib
 import shutil
 from typing import Optional
 
+from . import _utils
 from .fs import FS, FileStat
 
 
@@ -74,6 +75,14 @@ class Local(FS):
 
     def _reset(self):
         pass
+
+    def __repr__(self):
+        return _utils.format_repr(
+            Local,
+            {
+                "cwd": self._cwd,
+            },
+        )
 
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -4,8 +4,7 @@ import pathlib
 import shutil
 from typing import Optional
 
-from . import _utils
-from .fs import FS, FileStat
+from .fs import FS, FileStat, format_repr
 
 
 class LocalFileStat(FileStat):
@@ -77,7 +76,7 @@ class Local(FS):
         pass
 
     def __repr__(self):
-        return _utils.format_repr(
+        return format_repr(
             Local,
             {
                 "cwd": self._cwd,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -7,6 +7,7 @@ from typing import Optional, Type
 import boto3
 from botocore.exceptions import ClientError
 
+from . import _utils
 from .fs import FS, FileStat
 
 DEFAULT_MAX_BUFFER_SIZE = 16 * 1024 * 1024
@@ -382,6 +383,16 @@ class S3(FS):
 
     def __setstate__(self, state):
         self.__dict__ = state
+
+    def __repr__(self) -> str:
+        return _utils.format_repr(
+            S3,
+            {
+                "bucket": self.bucket,
+                "prefix": self.cwd,
+                "endpoint": self.endpoint
+            },
+        )
 
     def open(self, path, mode='r', **kwargs):
         '''Opens an object accessor for read or write

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -7,8 +7,7 @@ from typing import Optional, Type
 import boto3
 from botocore.exceptions import ClientError
 
-from . import _utils
-from .fs import FS, FileStat
+from .fs import FS, FileStat, format_repr
 
 DEFAULT_MAX_BUFFER_SIZE = 16 * 1024 * 1024
 
@@ -385,7 +384,7 @@ class S3(FS):
         self.__dict__ = state
 
     def __repr__(self) -> str:
-        return _utils.format_repr(
+        return format_repr(
             S3,
             {
                 "bucket": self.bucket,

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -7,6 +7,7 @@ from typing import Optional, Set
 
 from pfio.cache.sparse_file import MPCachedWrapper
 
+from . import _utils
 from .fs import FS, FileStat
 
 logger = logging.getLogger(__name__)
@@ -132,6 +133,16 @@ class Zip(FS):
 
     def __setstate__(self, state):
         self.__dict__ = state
+
+    def __repr__(self):
+        return _utils.format_repr(
+            Zip,
+            {
+                "file_path": self.file_path,
+                "mode": self.mode,
+                "backend": self.backend,
+            },
+        )
 
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -7,8 +7,7 @@ from typing import Optional, Set
 
 from pfio.cache.sparse_file import MPCachedWrapper
 
-from . import _utils
-from .fs import FS, FileStat
+from .fs import FS, FileStat, format_repr
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -135,7 +134,7 @@ class Zip(FS):
         self.__dict__ = state
 
     def __repr__(self):
-        return _utils.format_repr(
+        return format_repr(
             Zip,
             {
                 "file_path": self.file_path,

--- a/tests/v2_tests/test_hdfs.py
+++ b/tests/v2_tests/test_hdfs.py
@@ -50,6 +50,11 @@ class TestHdfs(unittest.TestCase):
         self.hdfs.remove(self.dirname, recursive=True)
         self.hdfs.close()
 
+    def test_repr_str(self):
+        with Hdfs(self.dirname) as fs:
+            repr(fs)
+            str(fs)
+
     def test_read_non_exist(self):
         non_exist_file = "non_exist_file.txt"
 

--- a/tests/v2_tests/test_local.py
+++ b/tests/v2_tests/test_local.py
@@ -21,6 +21,11 @@ class TestLocal(unittest.TestCase):
     def tearDown(self):
         self.testdir.cleanup()
 
+    def test_repr_str(self):
+        with Local(self.testdir.name) as fs:
+            str(fs)
+            repr(fs)
+
     def test_read_string(self):
 
         with Local() as fs:

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -48,6 +48,12 @@ def test_s3_init(s3_fixture):
         assert s3.endpoint is None
 
 
+def test_s3_repr_str(s3_fixture):
+    with from_url('s3://test-bucket/base', **s3_fixture.aws_kwargs) as s3:
+        repr(s3)
+        str(s3)
+
+
 def test_s3_files(s3_fixture):
     with from_url('s3://test-bucket/base',
                   **s3_fixture.aws_kwargs) as s3:

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -114,6 +114,11 @@ class TestZip(unittest.TestCase):
         self.tmpdir.cleanup()
         local.remove(self.zip_file_path)
 
+    def test_repr_str(self):
+        with local.open_zip(self.zip_file_path) as z:
+            repr(z)
+            str(z)
+
     def test_read_bytes(self):
         with local.open_zip(os.path.abspath(self.zip_file_path)) as z:
             with z.open(self.zipped_file_path, "rb") as zipped_file:


### PR DESCRIPTION
It would be convenient if some information was included in `repr`.

```
<pfio.v2.local.Local object at 0x7f6b09c7d120>
```
↓
```
pfio.v2.local.Local(cwd='/')
```