### PR TITLE
Deprecate sparse file cache in 2.7 (and will be deleted in 2.8)

### DIFF
--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -100,6 +100,7 @@ class Zip(FS):
         # Use sparse file cache: Optimization for a remote object
         # store system e.g. AWS S3 or HDFS
         if self.local_cache:
+            # Will be removed in 2.8
             warnings.warn("Sparse file cache deprecated in 2.7",
                           DeprecationWarning)
 

--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import os
+import warnings
 import zipfile
 from datetime import datetime
 from typing import Optional, Set
@@ -99,6 +100,9 @@ class Zip(FS):
         # Use sparse file cache: Optimization for a remote object
         # store system e.g. AWS S3 or HDFS
         if self.local_cache:
+            warnings.warn("Sparse file cache deprecated in 2.7",
+                          DeprecationWarning)
+
             self.kwargs['buffering'] = buffering
 
             obj = MPCachedWrapper(obj, stat.size, self.local_cachedir,


### PR DESCRIPTION
In 1/2 favor of https://github.com/pfnet/pfio/issues/311 .