### PR TITLE
Remove v2.FS from v2.Path context

### DIFF
--- a/pfio/v2/pathlib.py
+++ b/pfio/v2/pathlib.py
@@ -18,7 +18,7 @@ class Path:
         '''
         self._fs = fs
         if fs is not None:
-            warnings.Warn("argument fs for Path is deprecated",
+            warnings.warn("argument fs for Path is deprecated",
                           DeprecationWarning)
             assert isinstance(self._fs, FS)
 


### PR DESCRIPTION
`pfio.v2.Path` shall be independent from `pfio.v2.FS` implementations such as S3 and so on as it includes too much information to represent generic paths and its manipulations. In this PR, it deprecates giving `pfio.v2.FS` to the constructor of `pfio.v2.Path`, and add a new method `.scope()` to `FS` for calling file access methods from Path such as `open` and `exists`. 

Before:

```python
with from_url('s3://bucket/path/to/dir') as s3:
  p = Path('path/to/file', fs=s3)
  p.open().read()
```

After this PR, we can do this:

```python
p = Path('path/to/file')
with from_url('s3://bucket/path/to/dir') as s3:
  with s3.scope():
    p.open().read()
```

Current style (above) remains supported for 2.7.x, but will be removed in 2.8.
