### PR TITLE
S3 support for large files

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -601,12 +601,10 @@ class S3(FS):
         }
         dst = os.path.join(self.cwd, dst)
         dst = _normalize_key(dst)
-        res = self.client.copy_object(Bucket=self.bucket,
-                                      CopySource=source,
-                                      Key=dst)
-        if not res.get('CopyObjectResult'):
-            # copy failed
-            return
+        res = self.client.copy(Bucket=self.bucket,
+                               CopySource=source,
+                               Key=dst)
+        print(f"{res=}")
         return self.remove(src)
 
     def remove(self, file_path: str, recursive=False):

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -202,7 +202,7 @@ class _ObjectWriter:
                 hashlib.md5(data.encode()).digest()
             ).decode()
         num = len(self.parts) + 1
-        
+
         res = c.upload_part(Body=data, Bucket=b, Key=k,
                             PartNumber=num,
                             UploadId=self.mpu_id,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -595,21 +595,18 @@ class S3(FS):
 
         '''
         self._checkfork()
-        src_key = _normalize_key(os.path.join(self.cwd, src))
+        source = {
+            'Bucket': self.bucket,
+            'Key': _normalize_key(os.path.join(self.cwd, src)),
+        }
         dst = os.path.join(self.cwd, dst)
         dst = _normalize_key(dst)
-        src_size = self.stat(src).size
-        mp = self.bucket.initial_multipart_upload(dst)
-
-        for i, start in enumerate(range(0, src_size, self.mpu_chunksize)):
-            print(f"Copying part {i + 1} from {start}...")
-            mp.copy_part_from_key(
-                self.bucket, 
-                src_key, 
-                i + 1,
-                start, 
-                min(src_size - 1, start + self.mpu_chunksize - 1))
-        mp.upload_complete()
+        res = self.client.copy_object(Bucket=self.bucket,
+                                      CopySource=source,
+                                      Key=dst)
+        if not res.get('CopyObjectResult'):
+            # copy failed
+            return
         return self.remove(src)
 
     def remove(self, file_path: str, recursive=False):

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -601,10 +601,9 @@ class S3(FS):
         }
         dst = os.path.join(self.cwd, dst)
         dst = _normalize_key(dst)
-        res = self.client.copy(Bucket=self.bucket,
-                               CopySource=source,
-                               Key=dst)
-        print(f"{res=}")
+        self.client.copy(Bucket=self.bucket,
+                         CopySource=source,
+                         Key=dst)
         return self.remove(src)
 
     def remove(self, file_path: str, recursive=False):

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -1,5 +1,5 @@
-import hashlib
 import base64
+import hashlib
 import io
 import os
 import urllib.parse

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -198,9 +198,6 @@ class _ObjectWriter:
         else:
             md5 = base64.b64encode(hashlib.md5(data.encode()).digest()).decode()
         num = len(self.parts) + 1
-        print(f"{md5=}")
-        print(f"{len(data)}")
-        print(f"{type(data)=}")
         res = c.upload_part(Body=data, Bucket=b, Key=k,
                             PartNumber=num,
                             UploadId=self.mpu_id,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -1,4 +1,5 @@
 import hashlib
+import base64
 import io
 import os
 import urllib.parse
@@ -193,11 +194,13 @@ class _ObjectWriter:
 
         data = self.buf.getvalue()
         if 'b' in self.mode:
-            md5 = hashlib.md5(data).hexdigest()
+            md5 = base64.b64encode(hashlib.md5(data).digest()).decode()
         else:
-            md5 = hashlib.md5(data.encode()).hexdigest()
+            md5 = base64.b64encode(hashlib.md5(data.encode()).digest()).decode()
         num = len(self.parts) + 1
-
+        print(f"{md5=}")
+        print(f"{len(data)}")
+        print(f"{type(data)=}")
         res = c.upload_part(Body=data, Bucket=b, Key=k,
                             PartNumber=num,
                             UploadId=self.mpu_id,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -202,6 +202,7 @@ class _ObjectWriter:
                 hashlib.md5(data.encode()).digest()
             ).decode()
         num = len(self.parts) + 1
+        
         res = c.upload_part(Body=data, Bucket=b, Key=k,
                             PartNumber=num,
                             UploadId=self.mpu_id,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -194,9 +194,13 @@ class _ObjectWriter:
 
         data = self.buf.getvalue()
         if 'b' in self.mode:
-            md5 = base64.b64encode(hashlib.md5(data).digest()).decode()
+            md5 = base64.b64encode(
+                hashlib.md5(data).digest()
+            ).decode()
         else:
-            md5 = base64.b64encode(hashlib.md5(data.encode()).digest()).decode()
+            md5 = base64.b64encode(
+                hashlib.md5(data.encode()).digest()
+            ).decode()
         num = len(self.parts) + 1
         res = c.upload_part(Body=data, Bucket=b, Key=k,
                             PartNumber=num,


### PR DESCRIPTION
Current code on `master` fails to handle large files on AWS S3 in 2 ways:
1. When performing multi-part uploading, the md5 given to `upload_part` is hexadecimal, but base64 is expected.
2. When calling `S3.rename` with a source object larger than 5GB, it fails due to limitations of `copy_object`.

While issue 1. is a straightforward fix. Solving issue 2. requires using multi-part copying, which (in my understanding) makes `rename` no longer atomic for large files. Considering `rename` is often used for its atomicity, I'm not sure whether this solution is best, and would be happy to get feedback.