### PR TITLE
Fix document build fail and add status badge

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## PFIO
 
+![Doc Status Badge](https://readthedocs.org/projects/pfio/badge/?version=master&style=flat)
+
 PFIO is an IO abstraction library developed by PFN, optimized for deep
 learning training with batteries included. It supports
 


### PR DESCRIPTION
Please check the build success at https://readthedocs.org/projects/pfio/builds/ .