### PR TITLE
Path: more compatibility with pathlib.Path

### DIFF
--- a/pfio/v2/pathlib.py
+++ b/pfio/v2/pathlib.py
@@ -1,271 +1,756 @@
-import fnmatch
-import os
-from pathlib import PurePath
+import functools
+import uuid
+from fnmatch import fnmatch, fnmatchcase
+from io import IOBase
+from os import PathLike
+from pathlib import PurePosixPath
+from posixpath import join as joinpath
+from posixpath import normpath
+from sys import version_info as python_version_info
+from typing import (Callable, Iterator, List, Optional, Sequence, Set, Tuple,
+                    Type, TypeVar, Union)
+from urllib.parse import ParseResult, urlunparse
 
-from .fs import FS
+from .fs import FS, FileStat
+from .hdfs import Hdfs
 from .local import Local
+from .s3 import S3
+from .zip import Zip
+
+SelfPurePathType = TypeVar("SelfPurePathType", bound="PurePath")
+SelfPathType = TypeVar("SelfPathType", bound="Path")
 
 
-class Path:
-    sep = '/'
+@functools.lru_cache(maxsize=16)
+def _has_directory_feature(fs: FS) -> bool:
+    if isinstance(fs, S3):
+        # NOTE: Apache Ozone supports supports directory or folder.
+        # refers to `ozone.om.enable.filesystem.paths` property.
+        dpath = f"__pfio_check_{str(uuid.uuid4())[:8]}"
+        upath = f"{dpath}/__tmp"
 
-    def __init__(self, *args, fs=None, root=None):
-        '''
+        with fs.open(upath, mode="wb") as f:
+            f.write(b"")
+        fs.remove(upath)
 
-        Empty argument indicates current directory in fs, fs.cwd
-
-        '''
-        self._fs = fs if fs else Local()
-        assert isinstance(self._fs, FS)
-
-        sep = self.sep
-        if root:
-            if not root.startswith(self.sep):
-                raise ValueError("root must start with a separator.")
-            if root == self.sep:
-                args = [self.sep] + args
-            else:
-                args = [self.sep, root[len(self.sep):]] + args
-
-        # Construct parts
-        parts = []
-        for argv in args:
-            p = argv
-            if p.startswith(sep):
-                parts = [sep]
-                p = p[len(sep):]
-            if len(p) > 0:
-                parts += [q for q in p.split(sep) if q not in ("", ".")]
-
-        # Check
-        assert "" not in parts
-        if parts and parts[0] == self.sep:
-            assert all(self.sep not in p for p in parts[1:])
-        else:
-            assert all(self.sep not in p for p in parts)
-
-        self._parts = parts
-
-    @property
-    def name(self):
-        if not self._parts:
-            return ""
-        if len(self._parts) == 1 and self._parts[0] == self.sep:
-            return ""
-        return os.path.normpath(self._parts[-1])
-
-    @property
-    def suffix(self):
-        return os.path.splitext(self.resolve())[1]
-
-    def with_suffix(self, ext):
-        assert ext.startswith('.')
-        name = self.name
-        if name == "":
-            raise ValueError(f"{self} has an empty name")
-        base, _ = os.path.splitext(name)
-        return self.parent / f"{base}{ext}"
-
-    @property
-    def parent(self):
-        if not self._parts:
-            return self
-
-        if self._parts[0] == self.sep and len(self._parts) == 1:
-            return self
-
-        return Path(*(self._parts[:-1]), fs=self._fs)
-
-    @property
-    def parts(self):
-        return tuple(self._parts)
-
-    @property
-    def root(self):
-        if self._parts and self._parts[0] == self.sep:
-            return self.sep
-        return ""
-
-    def __rtruediv__(self, a):
-        if isinstance(a, str):
-            lhs = Path(a, fs=self._fs)
-        else:
-            lhs = a
-        return lhs / self
-
-    def __truediv__(self, a):
-        parts = self._parts[:]
-        if isinstance(a, Path):
-            parts += a._parts
-        elif isinstance(a, PurePath):
-            raise RuntimeError("mixed")
-        else:
-            parts.append(str(a))
-
-        p = Path(*parts, fs=self._fs)
-        return p
-
-    @classmethod
-    def cwd(cls):
-        raise NotImplementedError("cwd() is unsupported on this system")
-
-    @classmethod
-    def home(cls):
-        raise NotImplementedError("home() is unsupported on this system")
-
-    def exists(self):
-        return self._fs.exists(str(self.resolve()))
-
-    def is_absolute(self):
-        return self._parts and self._parts[0] == self.sep
-
-    def __repr__(self):
-        return "{}[{}:{}]".format(self.__class__.__name__,
-                                  self._fs.__class__.__name__,
-                                  str(self))
-
-    def __str__(self):
-        if not self._parts:
-            return "."
-        if self._parts[0] == self.sep:
-            return self.sep + self.sep.join(self._parts[1:])
-        return self.sep.join(self._parts)
-
-    def __fspath__(self):
-        return str(self)
-
-    def __lt__(self, other):
-        return str(self) < str(other)
-
-    def resolve(self, strict=True):
-        if '..' in self._parts or '.' in self._parts:
-            raise RuntimeError("TODO")
-        return Path(*(self._fs.cwd, *self._parts), fs=self._fs)
-
-    def samefile(self, other):
-        # TODO: Compare self._fs
-        return str(self.resolve()) == str(other.resolve())
-
-    def touch(self):
-        with self._fs.open(self.resolve(), 'wb') as fp:
-            fp.write(b'')
-
-    def open(self, mode='r', **kwargs):
-        # TODO: handle or warn on ignoring these keyword arguments
-        # buffering=-1, encoding=None, errors=None, newline=None):
-        return self._fs.open(self.resolve(), mode)
-
-    def mkdir(self, mode=0o777, parents=False, exist_ok=False):
-        if parents:
-            return self._fs.makedirs(self.resolve(), mode, exist_ok)
-
-        try:
-            self._fs.mkdir(self.resolve(), mode)
-        except FileExistsError as e:
-            if not exist_ok:
-                raise e
-            else:
-                pass
-
-    def is_dir(self):
-        return self._fs.isdir(self.resolve())
-
-    def is_file(self):
-        return not self._fs.isdir(self.resolve())
-
-    def iterdir(self):
-        return self.glob("*")
-
-    def glob(self, pattern):
-        '''glob
-
-        It may be slow depending on the filesystem type.
-        '''
-        # Try specialized implementation
-        with self._as_fs() as fs:
-            try:
-                generator = fs.glob(pattern)
-            except NotImplementedError:
-                pass
-            else:
-                return (self / f for f in generator)
-
-        # Fall back to slower generic implementation
-        return self._glob_generic(pattern)
-
-    def _glob_generic(self, pattern):
-        '''Slow and generic implementation of glob.'''
-        base = self.resolve()
-        base_parts = base._parts
-        pattern_parts = (base / pattern)._parts
-
-        visited_prefixes = set()
-        for p in self._fs.list(base, recursive=True):
-            parent = p
-
-            while (i := parent.rfind(self.sep)) != -1:
-                parent = parent[:i]
-                if parent in visited_prefixes:
-                    continue
-                visited_prefixes.add(parent)
-
-                target_parts = (base / parent)._parts
-
-                if _test_glob_by_parts(target_parts, pattern_parts):
-                    yield self / parent
-
-            target_parts = base_parts + p.split("/")
-
-            if _test_glob_by_parts(target_parts, pattern_parts):
-                yield self / p
-
-    def stat(self):
-        return self._fs.stat(self.resolve())
-
-    def unlink(self, missing_ok=False):
-        return self._fs.remove(self.resolve())
-
-    def rename(self, target):
-        raise NotImplementedError("rename() is unsupported on this system")
-
-    def read_text(self):
-        with self.open() as fp:
-            return fp.read()
-
-    def read_bytes(self):
-        with self.open(mode='rb') as fp:
-            return fp.read()
-
-    def write_text(self, data):
-        with self.open(mode='w') as fp:
-            return fp.write(data)
-
-    def write_bytes(self, data):
-        view = memoryview(data)
-        with self.open(mode='wb') as fp:
-            return fp.write(view)
-
-    def _as_fs(self):
-        return self._fs._newfs(str(self.resolve()))
-
-
-def _test_glob_by_parts(target_parts, pattern_parts):
-    target_parts = target_parts[:]
-    pattern_parts = pattern_parts[:]
-    while True:
-        if len(target_parts) == 0 and len(pattern_parts) == 0:
+        # NOTE: directory creates automatically
+        #       if `ozone.om.enable.filesystem.paths` is enabled.
+        if fs.exists(dpath):
+            fs.remove(dpath)
             return True
-
-        if len(target_parts) == 0 or len(pattern_parts) == 0:
+        else:
             return False
+    else:
+        return True
 
-        p = pattern_parts.pop(0)
-        if p == "**":
-            for i in range(0, len(target_parts)):
-                if _test_glob_by_parts(target_parts[i:], pattern_parts):
+
+def _removeprefix(text: str, prefix: str) -> str:
+    # NOTE: `str.removeprefix` supports version 3.9 or higher.
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+
+def _compare_fs(lhs: FS, rhs: FS) -> bool:
+    if type(lhs) is type(rhs):
+        assert isinstance(lhs.cwd, str)
+        assert isinstance(rhs.cwd, str)
+
+        if isinstance(lhs, Local) and isinstance(rhs, Local):
+            return lhs.cwd == rhs.cwd
+        elif isinstance(lhs, S3) and isinstance(rhs, S3):
+            return (
+                lhs.cwd == rhs.cwd
+                and lhs.bucket == rhs.bucket
+                and lhs.endpoint == rhs.endpoint
+            )
+        elif isinstance(lhs, Hdfs) and isinstance(rhs, Hdfs):
+            return lhs.cwd == rhs.cwd and lhs.username == rhs.username
+        elif isinstance(lhs, Zip) and isinstance(rhs, Zip):
+            return lhs.cwd == rhs.cwd
+        else:
+            raise ValueError(f"unsupported FS: {lhs} and {rhs}")
+
+    return False
+
+
+def _not_supported(name: Optional[str] = None) -> NotImplementedError:
+    if not name:
+        import inspect
+
+        stack = inspect.stack()
+        cname = stack[1].frame.f_locals["self"].__class__.__name__
+        fname = stack[1].function
+        name = f"{cname}.{fname}"
+
+    return NotImplementedError(f"`{name}` is unsupported on this system")
+
+
+class PurePath(PathLike):
+    """
+    `pathlib.PurePosixPath` compatible interface.
+
+    Args:
+        args: construct paths.
+        fs: target file system.
+        scheme: specify URL scheme. (for `as_uri` method)
+
+    Note:
+        It conforms to `pathlib.PurePosixPath` of Python 3.12 specification.
+
+        this class not inherits any `pathlib` classes because
+        pfio filesystems is not suitable for pathlib abstact
+        and helper classes.
+
+    TODO:
+        `scheme` should moves to `FS`.
+    """
+
+    def __init__(
+        self,
+        *args: Union[str, PathLike],
+        fs: FS,
+        scheme: Optional[str] = None,
+    ) -> None:
+        if isinstance(fs, Local):
+            scheme = scheme or "file"
+        elif isinstance(fs, S3):
+            scheme = scheme or "s3"
+        elif isinstance(fs, Hdfs):
+            scheme = scheme or "hdfs"
+        elif isinstance(fs, Zip):
+            scheme = scheme or ""
+        else:
+            raise ValueError(f"unsupported FS: {fs}")
+
+        self._fs: FS = fs
+        self._scheme = scheme
+        self._pure = PurePosixPath(*args)
+        self._hash = hash(self._pure) + hash(self._fs) + hash(self._scheme)
+
+    @property
+    def sep(self) -> str:
+        return "/"
+
+    @property
+    def scheme(self) -> str:
+        return self._scheme
+
+    def __hash__(self) -> int:
+        return self._hash
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, PurePath):
+            return self._pure == other._pure and _compare_fs(
+                self._fs, other._fs
+            )
+        else:
+            return NotImplemented
+
+    def __fspath__(self) -> str:
+        return self._pure.__fspath__()
+
+    def __str__(self) -> str:
+        return self.__fspath__()
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}('{self.__fspath__()}')"
+
+    def __bytes__(self) -> bytes:
+        return self._pure.__bytes__()
+
+    def __truediv__(
+        self: SelfPurePathType,
+        other: Union[str, PathLike, SelfPurePathType],
+    ) -> SelfPurePathType:
+        try:
+            return self.with_segments(self._pure / str(other))
+        except TypeError:
+            return NotImplemented
+
+    def __rtruediv__(
+        self: SelfPurePathType,
+        other: Union[str, PathLike, SelfPurePathType],
+    ) -> SelfPurePathType:
+        try:
+            return self.with_segments(str(other) / self._pure)
+        except TypeError:
+            return NotImplemented
+
+    # ---------------------------------------
+    # pathlib.PurePath compatible properties
+    # ---------------------------------------
+
+    @property
+    def parts(self) -> Tuple[str, ...]:
+        return self._pure.parts
+
+    @property
+    def drive(self) -> str:
+        return self._pure.drive
+
+    @property
+    def root(self) -> str:
+        return self._pure.root
+
+    @property
+    def anchor(self) -> str:
+        return self._pure.anchor
+
+    @property
+    def parents(self: SelfPurePathType) -> Sequence[SelfPurePathType]:
+        # FIXME: reduce costs
+        p = self.parts
+        paths = [self.with_segments(*p[:-i]) for i in range(1, len(p) + 1)]
+        if self.is_absolute():
+            paths.pop(-1)
+        return paths
+
+    @property
+    def parent(self: SelfPurePathType) -> SelfPurePathType:
+        return self.with_segments(self._pure.parent)
+
+    @property
+    def name(self) -> str:
+        return self._pure.name
+
+    @property
+    def suffix(self) -> str:
+        return self._pure.suffix
+
+    @property
+    def suffixes(self) -> List[str]:
+        return self._pure.suffixes
+
+    @property
+    def stem(self) -> str:
+        return self._pure.stem
+
+    # ---------------------------------------
+    # pathlib.PurePath compatible methods
+    # ---------------------------------------
+
+    def as_posix(self) -> str:
+        return self._pure.as_posix()
+
+    def as_uri(self) -> str:
+        if self.is_absolute():
+            if isinstance(self._fs, S3):
+                netloc = self._fs.bucket
+                assert isinstance(netloc, str)
+            elif isinstance(self._fs, Hdfs):
+                raise NotImplementedError
+            else:
+                netloc = ""
+
+            prefix = self._fs.cwd
+            assert isinstance(prefix, str)
+            key = _removeprefix(self.as_posix(), self.sep)
+
+            parsed = ParseResult(
+                scheme=self.scheme,
+                netloc=netloc,
+                path=joinpath(prefix, key),
+                params="",
+                query="",
+                fragment="",
+            )
+            return urlunparse(parsed)
+
+        else:
+            raise ValueError(f"'{self}' is not absolute path")
+
+    def is_absolute(self) -> bool:
+        return self._pure.is_absolute()
+
+    def is_relative_to(self, *other: Union[str, PathLike]) -> bool:
+        if python_version_info.minor < 9:
+            raise NotImplementedError(
+                "`is_relative_to()` supports python 3.9 or higher"
+            )
+        else:
+            return self._pure.is_relative_to(*other)  # type: ignore
+
+    def is_reserved(self) -> bool:
+        return self._pure.is_reserved()
+
+    def joinpath(
+        self: SelfPurePathType,
+        *args: Union[str, PathLike],
+    ) -> SelfPurePathType:
+        return self.with_segments(self._pure.joinpath(*args))
+
+    def match(
+        self,
+        pattern: Union[str, PathLike],
+        *,
+        case_sensitive: bool = False,
+    ) -> bool:
+        pattern = str(pattern)
+        if case_sensitive:
+            return fnmatchcase(self.as_uri(), pattern)
+        else:
+            return fnmatch(self.as_uri(), pattern)
+
+    def relative_to(
+        self: SelfPurePathType,
+        *other: Union[str, PathLike],
+        walk_up: bool = False,
+    ) -> SelfPurePathType:
+        if python_version_info.minor < 12 and walk_up:
+            raise NotImplementedError(
+                "`walk_up=True` supports python version 3.12 or higher"
+            )
+
+        if python_version_info.minor >= 12:
+            rel = self._pure.relative_to(
+                *other,
+                walk_up=walk_up,  # type: ignore
+            )
+        else:
+            rel = self._pure.relative_to(*other)
+
+        return self.with_segments(rel)
+
+    def with_name(self: SelfPurePathType, name: str) -> SelfPurePathType:
+        return self.with_segments(self._pure.with_name(name))
+
+    def with_stem(self: SelfPurePathType, stem: str) -> SelfPurePathType:
+        if python_version_info.minor < 9:
+            raise NotImplementedError(
+                "`with_stem()` supports python 3.9 or higher"
+            )
+        else:
+            return self.with_segments(
+                self._pure.with_stem(stem)  # type: ignore
+            )
+
+    def with_suffix(self: SelfPurePathType, suffix: str) -> SelfPurePathType:
+        return self.with_segments(self._pure.with_suffix(suffix))
+
+    def with_segments(
+        self: SelfPurePathType,
+        *args: Union[str, PathLike],
+    ) -> SelfPurePathType:
+        return type(self)(*args, fs=self._fs, scheme=self.scheme)
+
+
+class Path(PurePath):
+    """
+    `pathlib.PosixPath` compatible interface.
+
+    Args:
+        args: construct paths.
+        fs: target file system.
+        scheme: specify URL scheme. (for `as_uri` method)
+
+    Note:
+        many methods raise `NotImplementedError`
+        because they require unsupported features of `FS`.
+
+        several methods behave slightly different,
+        - `stat` returns `FileStat` object instead of `os.stat_result`.
+        - `glob`, `rglob`, `iterdir` will not return directory type object.
+    """
+
+    def __init__(
+        self,
+        *args: str,
+        fs: FS,
+        scheme: Optional[str] = None,
+    ) -> None:
+        super().__init__(*args, fs=fs, scheme=scheme)
+
+    def _as_relative_to_fs(self) -> str:
+        return _removeprefix(self.as_posix(), self.anchor)
+
+    # ---------------------------------------
+    # pathlib.Path compatible classmethods
+    # ---------------------------------------
+
+    @classmethod
+    def cwd(cls: Type[SelfPathType]) -> SelfPathType:
+        raise _not_supported()
+
+    @classmethod
+    def home(cls: Type[SelfPathType]) -> SelfPathType:
+        raise _not_supported()
+
+    # ---------------------------------------
+    # pathlib.Path compatible methods
+    # ---------------------------------------
+
+    def stat(self, *, follow_symlinks: bool = True) -> FileStat:
+        if not follow_symlinks:
+            raise _not_supported("follow_symlinks=False")
+
+        return self._fs.stat(self._as_relative_to_fs())
+
+    def chmod(self, *, follow_symlinks: bool = True) -> None:
+        raise _not_supported()
+
+    def exists(self, *, follow_symlinks: bool = True) -> bool:
+        if not follow_symlinks:
+            raise _not_supported("follow_symlinks=False")
+
+        return self.is_file() or self.is_dir()
+
+    def expanduser(self: SelfPathType) -> SelfPathType:
+        raise _not_supported()
+
+    def glob(
+        self: SelfPathType,
+        pattern: str,
+        *,
+        case_sensitive: Optional[bool] = None,
+    ) -> Iterator[SelfPathType]:
+        if case_sensitive is not None:
+            raise _not_supported("case_sensitive=True or False")
+
+        match_ = fnmatchcase if case_sensitive else fnmatch
+
+        p = self._as_relative_to_fs()
+        recursive = "**" in pattern
+
+        # NOTE: `pathlib.Path.glob` interprets "**/*" to "*"
+        if pattern.endswith("**/*"):
+            pattern = pattern.replace("**/*", "*")
+        pattern = pattern.replace("**", "*")
+
+        prefixes: Set[SelfPathType] = set()
+
+        # NOTE: `S3.glob` is not implemented...
+        #       it use `FS.list` instead of `glob`.
+        try:
+            for entry in self._fs.list(p, recursive=recursive):
+                assert isinstance(entry, str)
+
+                e = self.with_segments(*self.parts)
+                for part in entry.split(self.sep):
+                    if part:
+                        e = e / part
+                        if e not in prefixes and match_(str(e), pattern):
+                            prefixes.add(e)
+                            yield e
+        except FileNotFoundError:
+            # NOTE: raise from `os.scandir` in `Local` class.
+            pass
+
+    def group(self) -> str:
+        raise _not_supported()
+
+    def is_dir(self) -> bool:
+        p = self._as_relative_to_fs() + self.sep
+
+        if _has_directory_feature(self._fs):
+            return self._fs.isdir(p)  # type: ignore
+        else:
+            # FIXME: `S3.isdir` has a bug (?)
+            for entry in self._fs.list(p, recursive=True):
+                assert isinstance(entry, str)
+                if entry and not entry.endswith(self.sep):
                     return True
             return False
 
-        t = target_parts.pop(0)
-        if not fnmatch.fnmatch(t, p):
-            return False
+    def is_file(self) -> bool:
+        p = self._as_relative_to_fs()
+        return self._fs.exists(p) and not self._fs.isdir(p)
+
+    def is_junction(self) -> bool:
+        return False  # only Windows supports junctions
+
+    def is_mount(self) -> bool:
+        raise _not_supported()
+
+    def is_symlink(self) -> bool:
+        raise _not_supported()
+
+    def is_socket(self) -> bool:
+        raise _not_supported()
+
+    def is_fifo(self) -> bool:
+        raise _not_supported()
+
+    def is_block_device(self) -> bool:
+        raise _not_supported()
+
+    def is_char_device(self) -> bool:
+        raise _not_supported()
+
+    def iterdir(self: SelfPathType) -> Iterator[SelfPathType]:
+        if self.is_dir():
+            for entry in self._fs.list(self._as_relative_to_fs()):
+                assert isinstance(entry, str)
+                yield self.with_segments(*self.parts, entry)
+        else:
+            raise NotADirectoryError(f"'{self.as_posix()}' is not a directory")
+
+    def walk(
+        self,
+        top_down: bool = True,
+        on_error: Optional[Callable] = None,
+        follow_symlinks: bool = False,
+    ) -> Iterator[Tuple["Path", List[str], List[str]]]:
+        raise _not_supported()
+
+    def lchmod(self, mode: int) -> None:
+        raise _not_supported()
+
+    def lstat(self) -> FileStat:
+        raise _not_supported()
+
+    def mkdir(
+        self,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
+        if _has_directory_feature(self._fs):
+            if not parents and not self.parent.is_dir():
+                raise FileNotFoundError(
+                    f"'{self.parent.as_posix()}' is not a directory"
+                )
+
+            self._fs.makedirs(
+                self._as_relative_to_fs(),
+                mode=mode,
+                exist_ok=exist_ok,
+            )
+
+    def open(
+        self,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> IOBase:
+        # NOTE: first argument is `file_path`` in `Local`,
+        #       but `S3` is `path`.
+        return self._fs.open(  # type: ignore
+            self._as_relative_to_fs(),
+            mode=mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        )
+
+    def owner(self) -> str:
+        raise _not_supported()
+
+    def read_bytes(self) -> bytes:
+        with self.open(mode="rb", buffering=0) as f:
+            return f.read()  # type: ignore
+
+    def read_text(
+        self,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+    ) -> str:
+        with self.open(mode="rt", encoding=encoding, errors=errors) as f:
+            return f.read()  # type: ignore
+
+    def readlink(self: SelfPathType) -> SelfPathType:
+        raise _not_supported()
+
+    def rename(
+        self: SelfPathType,
+        target: Union[str, PurePath],
+    ) -> SelfPathType:
+        if isinstance(self._fs, S3):
+            # NOTE: S3 API does not support rename a `prefix`.
+            #       we implemented by `copy` + `remove`.
+            #       it is generic but poor performance...
+            target = self.with_segments(
+                _removeprefix(str(target), self.anchor)
+            )
+            copy(self, target)
+            unlink(self)
+        else:
+            target = (
+                _removeprefix(target.as_posix(), self.anchor)
+                if isinstance(target, PurePath)
+                else target
+            )
+            self._fs.rename(self._as_relative_to_fs(), target)
+
+        return self.with_segments(str(target))
+
+    def replace(
+        self: SelfPathType,
+        target: Union[str, PurePath],
+    ) -> SelfPathType:
+        return self.rename(target)
+
+    def absolute(self: SelfPathType) -> SelfPathType:
+        return self.with_segments("/" / self._pure)
+
+    def resolve(self: SelfPathType, strict: bool = False) -> SelfPathType:
+        # NOTE: symbolic link is not supported
+        normalized_path = normpath(self._as_relative_to_fs())
+        resolved_path = self.with_segments(normalized_path).absolute()
+        if strict and not resolved_path.exists():
+            raise FileNotFoundError(f"'{self.as_posix()}' not found")
+        return resolved_path
+
+    def rglob(
+        self: SelfPathType,
+        pattern: str,
+        *,
+        case_sensitive: Optional[bool] = None,
+    ) -> Iterator[SelfPathType]:
+        return self.glob(
+            joinpath("**", _removeprefix(pattern, self.sep)),
+            case_sensitive=case_sensitive,
+        )
+
+    def rmdir(self) -> None:
+        if _has_directory_feature(self._fs):
+            if self.is_dir():
+                self._fs.remove(self._as_relative_to_fs())
+            else:
+                raise NotADirectoryError(
+                    f"'{self.as_posix()}' is not a directory"
+                )
+
+    def samefile(self, other_path: Union[str, SelfPathType]) -> bool:
+        raise _not_supported()
+
+    def symlink_to(
+        self,
+        target: Union[str, PathLike],
+        target_is_directory: bool = False,
+    ) -> None:
+        raise _not_supported()
+
+    def hardlink_to(self, target: Union[str, PathLike]) -> None:
+        raise _not_supported()
+
+    def touch(self, mode: int = 0o666, exist_ok: bool = True) -> None:
+        if self.exists() and not exist_ok:
+            raise FileExistsError(f"'{self.as_posix()}' exists")
+
+        with self.open("wb") as f:
+            f.write(b"")
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        if self.is_dir():
+            raise IsADirectoryError(f"'{self.as_posix()}' is a directory")
+        elif self.is_file():
+            self._fs.remove(self._as_relative_to_fs())
+        elif not missing_ok:
+            raise FileNotFoundError(f"'{self.as_posix()}' is not a file")
+
+    def write_bytes(self, data: bytes) -> int:
+        with self.open(mode="wb") as f:
+            return f.write(data)  # type: ignore
+
+    def write_text(
+        self,
+        data: str,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> int:
+        with self.open(
+            mode="wt",
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        ) as f:
+            return f.write(data)  # type: ignore
+
+
+def copy(
+    src: Path,
+    dst: Path,
+    *,
+    chunk_size: int = 16 * (2**20),
+) -> None:
+    """
+    simplified copy interface.
+
+    Args:
+        src: source path of file or directory.
+        dst: destination path of file or directory.
+        chunk_size: blob size to copy object.
+
+    Note:
+        if `src` is a directory, all child entries in
+        directory will copied to `dst` recursively.
+    """
+
+    src = src.resolve()
+    dst = dst.resolve()
+
+    if src.is_file():
+        if dst.is_dir():
+            raise IsADirectoryError(f"{dst.as_uri()} is a directory")
+
+        with src.open("rb") as rf, dst.open("wb") as wf:
+            while chunk := rf.read(chunk_size):
+                wf.write(chunk)
+    elif src.is_dir():
+        if dst.is_file():
+            raise NotADirectoryError(f"{dst.as_uri()} is a file")
+
+        for entry in src.rglob("*"):
+            if entry.is_dir():
+                continue
+
+            entry = entry.relative_to(src)
+            prefix = entry.parent
+            (dst / prefix).mkdir(parents=True, exist_ok=True)
+
+            rf = (src / entry).open("rb")
+            wf = (dst / entry).open("wb")
+
+            with rf, wf:
+                while chunk := rf.read(chunk_size):
+                    wf.write(chunk)
+    else:
+        raise RuntimeError(f"unexpected storage object: {src.as_uri()}")
+
+
+def unlink(target: Path) -> None:
+    """
+    simplified remove interface.
+
+    Args:
+        target: path of file or directory.
+
+    Note:
+        if `target` is a directory, all child entries in
+        directory will removed recursively.
+    """
+
+    target = target.resolve()
+
+    if target.is_dir():
+        files: List[Path] = []
+        dirs: Set[Path] = set()
+        for entry in target.rglob("*"):
+            if entry.is_dir():
+                continue
+
+            if entry.is_file():
+                dirs.add(entry.parent)
+                files.append(entry)
+            else:
+                raise RuntimeError(f"unexpected entry: {entry.as_uri()}")
+
+        for f in files:
+            f.unlink(missing_ok=True)
+
+        _dirs = sorted(dirs, reverse=True, key=lambda s: len(str(s)))
+        for d in _dirs:
+            if d.is_dir():
+                d.rmdir()
+
+        if target.is_dir():
+            target.rmdir()
+    elif target.is_file():
+        target.unlink(missing_ok=True)
+    else:
+        raise RuntimeError(f"unexpected storage object: {target.as_uri()}")

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -1,221 +1,667 @@
-import contextlib
+import os
+import pathlib
 import tempfile
+import uuid
+from fnmatch import fnmatch
+from sys import version_info as python_version_info
+from typing import Any, Iterator, List, Optional, Tuple
+from urllib.parse import ParseResult, urlparse, urlunparse
 
+import boto3
 import pytest
 from moto import mock_aws
 
-from pfio.v2 import S3, Local, from_url, pathlib
+from pfio.v2 import Local, from_url
+from pfio.v2.pathlib import (Path, PurePath, _has_directory_feature,
+                             _removeprefix, unlink)
 
 
-def test_name():
-    p = pathlib.Path('foo.txt')
-    assert 'foo.txt' == p.name
+class TemporaryS3Bucket:
+    def __init__(self, name: Optional[str] = None) -> None:
+        self._name = name or str(uuid.uuid4())[:8]
+        self._client = boto3.resource("s3")
 
-    p = pathlib.Path('foo/')
-    assert 'foo' == p.name
+    def __enter__(self) -> str:
+        self._client.Bucket(self._name).create()
+        return f"s3://{self._name}"
 
-
-def test_suffix():
-    p = pathlib.Path('foo.txt')
-    assert '.txt' == p.suffix
-
-    assert 'foo.asc' == str(p.with_suffix('.asc'))
-    assert '.txt' == p.suffix
-
-
-def test_parent():
-    p = pathlib.Path('foo/foo.txt')
-    assert 'foo' == str(p.parent)
-
-    p = pathlib.Path('/')
-    assert '/' == str(p.parent)
-
-    # Not sure why Python's official pathlib works as Path().parent
-    # refers to Path('.') {fliptable}
-    # p = pathlib.Path()
-    # assert '.' == str(p.parent)
+    def __exit__(self, *args: Any) -> None:
+        bucket = self._client.Bucket(self._name)
+        bucket.objects.delete()
+        bucket.delete()
 
 
-def test_resolve():
-    p = pathlib.Path('/')
-    assert '/' == str(p.resolve())
+@pytest.fixture(params=["local", "s3"])
+def temporary_storage(request: pytest.FixtureRequest) -> Iterator[str]:
+    if request.param == "local":
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+    elif request.param == "s3":
+        with mock_aws():
+            with TemporaryS3Bucket() as tmpbucket:
+                yield tmpbucket
+    else:
+        raise RuntimeError
 
 
-def test_parts():
-    assert pathlib.Path().parts == ()
-    assert pathlib.Path('').parts == ()
-    assert pathlib.Path('.').parts == ()
-    assert pathlib.Path('/').parts == ('/',)
-    assert pathlib.Path('./').parts == ()
-    assert pathlib.Path('.//.').parts == ()
-    assert pathlib.Path('a').parts == ('a',)
-    assert pathlib.Path('/a').parts == ('/', 'a')
-    assert pathlib.Path('/a', 'bb/cc', 'dd').parts == (
-        '/', 'a', 'bb', 'cc', 'dd')
-    assert pathlib.Path('a', '/b', 'c').parts == ('/', 'b', 'c')
+@pytest.fixture
+def storage(temporary_storage: str) -> Iterator[str]:
+    with from_url(temporary_storage) as fs:
+        fs.makedirs("my/library/zoo")
+        fs.makedirs("my/foo/bar")
+
+        with fs.open("my/library/zoo/abc.txt", mode="wb") as f:
+            f.write(b"abcXYZ")
+
+        with fs.open("my/foo/bar/README.md", mode="w") as f:
+            f.write("HOWTO")
+
+        with fs.open("my/library/setup.py", mode="w") as f:
+            f.write("import os")
+
+        with fs.open("my/library/hoge.txt", mode="w") as f:
+            f.write("")
+
+        with fs.open("my/foo/zoo", mode="wb") as f:
+            f.write(b"hello")
+
+        with fs.open("my/library.tar.gz", mode="wb") as f:
+            f.write(b"body of library.tar.gz")
+
+    yield temporary_storage
 
 
-def test_root():
-    assert pathlib.Path().root == ''
-    assert pathlib.Path('').root == ''
-    assert pathlib.Path('.').root == ''
-    assert pathlib.Path('/').root == '/'
-    assert pathlib.Path('./').root == ''
-    assert pathlib.Path('.//.').root == ''
-    assert pathlib.Path('a').root == ''
-    assert pathlib.Path('/a').root == '/'
-    assert pathlib.Path('/a', 'bb/cc', 'dd').root == '/'
-    assert pathlib.Path('a', '/b', 'c').root == '/'
-
-
-@mock_aws
-def test_s3():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
-
-            p = pathlib.Path('foo', 'bar', 'baz', fs=s3)
-            assert '/base/foo/bar/baz' == str(p.resolve())
-            assert isinstance(p.resolve(), pathlib.Path)
-
-            assert not p.is_dir()
-            assert not p.is_absolute()
-            assert not p.exists()
-            p.touch()
-            assert p.exists()
-            assert '' == p.open().read()
-
-            p = pathlib.Path('/', 'foo', 'bar', 'baz', fs=s3)
-            assert '/foo/bar/baz' == str(p.resolve())
-            assert p.is_absolute()
-
-            p1 = pathlib.Path('/base', 'foo', 'bar', 'baz', fs=s3)
-            p2 = pathlib.Path('foo', 'bar', 'baz', fs=s3)
-            assert p1.samefile(p2)
-
-            # Path / operator
-            p3 = pathlib.Path('foo')
-            p4 = p1 / p3
-            assert '/base/foo/bar/baz/foo' == str(p4.resolve())
-
-            p5 = p2 / 'foo'
-            assert isinstance(p5, pathlib.Path)
-            p6 = 'foo2' / p2
-            p7 = p2 / 'bar' / 'fab'
-
-            assert '/base/foo/bar/baz/foo' == str(p5.resolve())
-            assert '/base/foo2/foo/bar/baz' == str(p6.resolve())
-            assert '/base/foo/bar/baz/bar/fab' == str(p7.resolve())
-
-            # Paths in S3 cannot be any directory
-            assert not p5.is_dir()
-
-
-def _setup_fs_fixture(fs):
-    # /base/0 ... /base/9
-    for i in range(3):
-        p = pathlib.Path(str(i), fs=fs)
-        p.touch()
-        assert p.exists()
-    # /0
-    pathlib.Path("dir", fs=fs).mkdir()
-    pathlib.Path("dir/0", fs=fs).touch()
-
-
-@contextlib.contextmanager
-def s3_fs():
-    bucket = "test-dummy-bucket"
-    key = "it's me!deadbeef"
-    secret = "asedf;lkjdf;a'lksjd"
-    with S3(bucket, create_bucket=True):
-        with from_url('s3://test-dummy-bucket/base',
-                      aws_access_key_id=key,
-                      aws_secret_access_key=secret) as s3:
-            _setup_fs_fixture(s3)
-            yield s3
-
-
-@contextlib.contextmanager
-def local_fs():
-    with tempfile.TemporaryDirectory() as tempd:
-        with from_url(tempd) as local:
-            _setup_fs_fixture(local)
-            yield local
-
-
-parameterize_fs = pytest.mark.parametrize(
-    'fs_fixture',
-    [s3_fs, local_fs]
+@pytest.mark.parametrize(
+    "p",
+    [
+        (),
+        ("",),
+        (".",),
+        ("/",),
+        ("my/library",),
+        ("my/library/setup.py",),
+        ("/usr/local/python",),
+    ],
 )
+def test_purepath_parts(
+    temporary_storage: str,
+    p: Tuple[str, ...],
+) -> None:
+    with from_url(temporary_storage) as fs:
+        actual = PurePath(*p, fs=fs)
+        expected = pathlib.PurePosixPath(*p)
+        assert actual.parts == expected.parts
 
 
-@parameterize_fs
-@mock_aws
-def test_s3_iterdir(fs_fixture):
-    with fs_fixture() as fs:
-        d = pathlib.Path(fs=fs)
-        files = list(d.iterdir())
-        assert 4 == len(files)
-        assert all([isinstance(f, pathlib.Path) for f in files])
-        assert all([f._fs is fs for f in files])
-        assert sorted(str(f) for f in files) == ["0", "1", "2", "dir"]
+@pytest.mark.parametrize(
+    "p",
+    [
+        (),
+        ("",),
+        (".",),
+        ("/",),
+        ("my/library",),
+        ("my/library/setup.py",),
+        ("/usr/local/python",),
+    ],
+)
+def test_purepath_string_operators(
+    temporary_storage: str,
+    p: Tuple[str, ...],
+) -> None:
+    with from_url(temporary_storage) as fs:
+        actual = PurePath(*p, fs=fs)
+        expected = pathlib.PurePosixPath(*p)
+        assert os.fspath(actual) == os.fspath(expected)
+        assert str(actual) == str(expected)
+        assert repr(actual) == repr(expected).replace(
+            "PurePosixPath", "PurePath"
+        )
+        assert bytes(actual) == bytes(expected)
 
 
-@parameterize_fs
-@mock_aws
-def test_s3_glob1(fs_fixture):
-    with fs_fixture() as fs:
-        d = pathlib.Path(fs=fs)
-        files = list(d.glob("*"))
-        assert 4 == len(files)
-        assert all([isinstance(f, pathlib.Path) for f in files])
-        assert all([f._fs is fs for f in files])
-        assert sorted(str(f) for f in files) == ["0", "1", "2", "dir"]
+@pytest.mark.parametrize(
+    "paths",
+    [
+        [(), ("/",)],
+        [("",), ("/usr",)],
+        [(".",), ("/tmp",)],
+        [("/",), (".",)],
+        [("my/library",), ("/my/library",)],
+        [("my/library/setup.py",), ("/my/library/setup.py",)],
+        [("/usr/local/python",), ("/usr/local/python3",)],
+    ],
+)
+def test_purepath_equal_operator(
+    temporary_storage: str,
+    paths: List[Tuple[str, ...]],
+) -> None:
+    with from_url(temporary_storage) as fs:
+        p, q = paths
+        expected = pathlib.PurePosixPath(*p)
+        actual = PurePath(*p, fs=fs)
+        assert expected == pathlib.PurePosixPath(*p)
+        assert expected != pathlib.PurePosixPath(*q)
+        assert actual == PurePath(*p, fs=fs)
+        assert actual != PurePath(*q, fs=fs)
 
 
-@parameterize_fs
-@mock_aws
-def test_s3_glob2(fs_fixture):
-    with fs_fixture() as fs:
+def test_purepath_truediv_operator(temporary_storage: str) -> None:
+    with from_url(temporary_storage) as fs:
+        expected = pathlib.PurePosixPath("/usr")
+        actual = PurePath("/usr", fs=fs)
+        assert expected / "hoge" == pathlib.PurePosixPath("/usr/hoge")
+        assert actual / "hoge" == PurePath("/usr/hoge", fs=fs)
+        assert expected / pathlib.PurePosixPath(
+            "hoge"
+        ) == pathlib.PurePosixPath("/usr/hoge")
+        assert actual / PurePath("hoge", fs=fs) == PurePath("/usr/hoge", fs=fs)
+
+        expected = pathlib.PurePosixPath("usr")
+        actual = PurePath("usr", fs=fs)
+        assert expected / "hoge" == pathlib.PurePosixPath("usr/hoge")
+        assert actual / "hoge" == PurePath("usr/hoge", fs=fs)
+        assert expected / pathlib.PurePosixPath(
+            "hoge"
+        ) == pathlib.PurePosixPath("usr/hoge")
+        assert actual / PurePath("hoge", fs=fs) == PurePath("usr/hoge", fs=fs)
+
+        expected = pathlib.PurePosixPath("/etc")
+        actual = PurePath("/etc", fs=fs)
+        assert expected / "/usr" == pathlib.PurePosixPath("/usr")
+        assert actual / "/usr" == PurePath("/usr", fs=fs)
+        assert expected / pathlib.PurePosixPath(
+            "/usr"
+        ) == pathlib.PurePosixPath("/usr")
+        assert actual / PurePath("/usr", fs=fs) == PurePath("/usr", fs=fs)
+
+        expected = pathlib.PurePosixPath("etc")
+        actual = PurePath("etc", fs=fs)
+        assert expected / "/usr" == pathlib.PurePosixPath("/usr")
+        assert actual / "/usr" == PurePath("/usr", fs=fs)
+        assert expected / pathlib.PurePosixPath(
+            "/usr"
+        ) == pathlib.PurePosixPath("/usr")
+        assert actual / PurePath("/usr", fs=fs) == PurePath("/usr", fs=fs)
+
+
+def test_purepath_rtruediv_operator(temporary_storage: str) -> None:
+    with from_url(temporary_storage) as fs:
+        expected = pathlib.PurePosixPath("usr")
+        actual = PurePath("usr", fs=fs)
+        assert "/etc" / expected == pathlib.PurePosixPath("/etc/usr")
+        assert "/etc" / actual == PurePath("/etc/usr", fs=fs)
+        assert pathlib.PurePosixPath(
+            "/etc"
+        ) / expected == pathlib.PurePosixPath("/etc/usr")
+        assert PurePath("/etc", fs=fs) / actual == PurePath("/etc/usr", fs=fs)
+
+        expected = pathlib.PurePosixPath("usr")
+        actual = PurePath("usr", fs=fs)
+        assert "etc" / expected == pathlib.PurePosixPath("etc/usr")
+        assert "etc" / actual == PurePath("etc/usr", fs=fs)
+        assert pathlib.PurePosixPath(
+            "etc"
+        ) / expected == pathlib.PurePosixPath("etc/usr")
+        assert PurePath("etc", fs=fs) / actual == PurePath("etc/usr", fs=fs)
+
+        expected = pathlib.PurePosixPath("/etc")
+        actual = PurePath("/etc", fs=fs)
+        assert "/usr" / expected == pathlib.PurePosixPath("/etc")
+        assert "/usr" / actual == PurePath("/etc", fs=fs)
+        assert pathlib.PurePosixPath(
+            "/usr"
+        ) / expected == pathlib.PurePosixPath("/etc")
+        assert PurePath("/usr", fs=fs) / actual == PurePath("/etc", fs=fs)
+
+        expected = pathlib.PurePosixPath("/etc")
+        actual = PurePath("/etc", fs=fs)
+        assert "usr" / expected == pathlib.PurePosixPath("/etc")
+        assert "usr" / actual == PurePath("/etc", fs=fs)
+        assert pathlib.PurePosixPath(
+            "usr"
+        ) / expected == pathlib.PurePosixPath("/etc")
+        assert PurePath("usr", fs=fs) / actual == PurePath("/etc", fs=fs)
+
+
+def test_purepath_joinpath(temporary_storage: str) -> None:
+    with from_url(temporary_storage) as fs:
+        expected = pathlib.PurePosixPath("/usr")
+        actual = PurePath("/usr", fs=fs)
+        assert expected.joinpath("hoge") == pathlib.PurePosixPath("/usr/hoge")
+        assert actual.joinpath("hoge") == PurePath("/usr/hoge", fs=fs)
+        assert expected.joinpath(
+            pathlib.PurePosixPath("hoge")
+        ) == pathlib.PurePosixPath("/usr/hoge")
+        assert actual.joinpath(PurePath("hoge", fs=fs)) == PurePath(
+            "/usr/hoge", fs=fs
+        )
+
+        expected = pathlib.PurePosixPath("usr")
+        actual = PurePath("usr", fs=fs)
+        assert expected.joinpath("hoge") == pathlib.PurePosixPath("usr/hoge")
+        assert actual.joinpath("hoge") == PurePath("usr/hoge", fs=fs)
+        assert expected.joinpath(
+            pathlib.PurePosixPath("hoge")
+        ) == pathlib.PurePosixPath("usr/hoge")
+        assert actual.joinpath(PurePath("hoge", fs=fs)) == PurePath(
+            "usr/hoge", fs=fs
+        )
+
+        expected = pathlib.PurePosixPath("/etc")
+        actual = PurePath("/etc", fs=fs)
+        assert expected.joinpath("/usr") == pathlib.PurePosixPath("/usr")
+        assert actual.joinpath("/usr") == PurePath("/usr", fs=fs)
+        assert expected.joinpath(
+            pathlib.PurePosixPath("/usr")
+        ) == pathlib.PurePosixPath("/usr")
+        assert actual.joinpath(PurePath("/usr", fs=fs)) == PurePath(
+            "/usr", fs=fs
+        )
+
+        expected = pathlib.PurePosixPath("etc")
+        actual = PurePath("etc", fs=fs)
+        assert expected.joinpath("/usr") == pathlib.PurePosixPath("/usr")
+        assert actual.joinpath("/usr") == PurePath("/usr", fs=fs)
+        assert expected.joinpath(
+            pathlib.PurePosixPath("/usr")
+        ) == pathlib.PurePosixPath("/usr")
+        assert actual.joinpath(PurePath("/usr", fs=fs)) == PurePath(
+            "/usr", fs=fs
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        "/",
+        "/usr",
+        "my/library/setup.py",
+    ],
+)
+def test_purepath_parents(
+    temporary_storage: str,
+    path: str,
+) -> None:
+    with from_url(temporary_storage) as fs:
+        expected = pathlib.PurePosixPath(path)
+        actual = PurePath(path, fs=fs)
+
+        expected_parents = expected.parents
+        actual_parents = actual.parents
+        assert len(actual_parents) == len(expected_parents)
+
+        for p, q in zip(actual_parents, expected_parents):
+            print(p.parts, q.parts)
+            assert p.parts == q.parts
+
+        assert actual.parent.parts == expected.parent.parts
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        "/",
+        ".",
+        "/usr/bin/python3",
+        "my/library",
+        "/my/library/setup.py",
+        "my/library.tar.gz",
+    ],
+)
+def test_purepath_compatible_properties(
+    temporary_storage: str,
+    path: str,
+) -> None:
+    with from_url(temporary_storage) as fs:
+        expected = pathlib.PurePosixPath(path)
+        actual = PurePath(path, fs=fs)
+
+        assert actual.drive == expected.drive
+        assert actual.root == expected.root
+        assert actual.anchor == expected.anchor
+        assert actual.name == expected.name
+        assert actual.suffix == expected.suffix
+        assert actual.suffixes == expected.suffixes
+        assert actual.stem == expected.stem
+
+
+def test_purepath_relative_to(temporary_storage: str) -> None:
+    with from_url(temporary_storage) as fs:
+        excepted = pathlib.PurePosixPath("/etc/passwd")
+        actual = PurePath("/etc/passwd", fs=fs)
+
+        assert excepted.relative_to("/") == pathlib.PurePosixPath("etc/passwd")
+        assert actual.relative_to("/") == PurePath("etc/passwd", fs=fs)
+
+        assert excepted.relative_to("/", "etc") == pathlib.PurePosixPath(
+            "passwd"
+        )
+        assert actual.relative_to("/", "etc") == PurePath("passwd", fs=fs)
+
+        excepted = pathlib.PurePosixPath("usr/local/lib")
+        actual = PurePath("usr/local/lib", fs=fs)
+
+        assert excepted.relative_to("usr/local") == pathlib.PurePosixPath(
+            "lib"
+        )
+        assert actual.relative_to("usr/local") == PurePath("lib", fs=fs)
+
+        with pytest.raises(ValueError):
+            excepted.relative_to("/usr")
+
+        with pytest.raises(ValueError):
+            actual.relative_to("/usr")
+
+        excepted = pathlib.PurePosixPath("usr/local/lib/")
+        actual = PurePath("usr/local/lib/", fs=fs)
+
+        assert excepted.relative_to("usr/local/") == pathlib.PurePosixPath(
+            "lib/"
+        )
+        assert actual.relative_to("usr/local/") == PurePath("lib/", fs=fs)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        "/",
+        ".",
+        "/usr/bin/python3",
+        "my/library",
+        "/my/library/setup.py",
+        "my/library.tar.gz",
+    ],
+)
+def test_purepath_compatible_methods(
+    temporary_storage: str,
+    path: str,
+) -> None:
+    with from_url(temporary_storage) as fs:
+        expected = pathlib.PurePath(path)
+        actual = PurePath(path, fs=fs)
+
+        assert actual.as_posix() == expected.as_posix()
+        assert actual.is_absolute() == expected.is_absolute()
+        assert actual.is_reserved() == expected.is_reserved()
+
+        if python_version_info.minor > 8:
+            assert expected.is_relative_to(str(actual))
+            assert actual.is_relative_to(str(expected))
+            assert not expected.is_relative_to("/mnt")
+            assert not actual.is_relative_to("/mnt")
+
+        if actual.is_absolute():
+            parsed = urlparse(temporary_storage, scheme="file")
+            unparsed = ParseResult(
+                parsed.scheme,
+                parsed.netloc,
+                os.path.join(parsed.path, _removeprefix(path, "/")),
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
+            assert actual.as_uri() == urlunparse(unparsed)
+        else:
+            with pytest.raises(ValueError):
+                expected.as_uri()
+
+            with pytest.raises(ValueError):
+                actual.as_uri()
+
+        if expected.name:
+            assert str(actual.with_name("XYZ.abc")) == str(
+                expected.with_name("XYZ.abc")
+            )
+        else:
+            with pytest.raises(ValueError):
+                actual.with_name("XYZ.abc")
+
+        if python_version_info.minor > 8:
+            if expected.stem:
+                assert str(actual.with_stem("a2z")) == str(
+                    expected.with_stem("a2z")
+                )
+            else:
+                with pytest.raises(ValueError):
+                    actual.with_stem("a2z")
+
+        if expected.name:
+            assert str(actual.with_suffix(".bz2")) == str(
+                expected.with_suffix(".bz2")
+            )
+        else:
+            with pytest.raises(ValueError):
+                actual.with_suffix(".bz2")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        "/",
+        ".",
+        "/usr/bin/python3",
+        "my/library",
+        "/my/library/setup.py",
+        "my/library.tar.gz",
+    ],
+)
+def test_path_stat(storage: str, path: str) -> None:
+    with from_url(url=storage) as fs:
+        p = Path(_removeprefix(path, "/"), fs=fs)
+        if p.is_file():
+            stat = p.stat()
+            assert stat.size > 0 or stat.last_modified is not None
+
+
+def test_absolute_resolve(storage: str) -> None:
+    with from_url(url=storage) as fs:
+        p = Path("my/library/../setup.py", fs=fs)
+
+        assert p.absolute() == Path("/my/library/../setup.py", fs=fs)
+        assert p.resolve() == Path("/my/setup.py", fs=fs)
+
+        with pytest.raises(FileNotFoundError):
+            p.resolve(strict=True)
+
+        resolved = Path("my/library/dummy/../setup.py", fs=fs).resolve(
+            strict=True
+        )
+        assert resolved == Path("/my/library/setup.py", fs=fs)
+
         if isinstance(fs, Local):
-            pytest.skip("Can't test absolute path for local FS")
-
-        d2 = pathlib.Path('/', fs=fs)
-        files = list(d2.glob("*"))
-        assert 1 == len(files)
-        assert all([isinstance(f, pathlib.Path) for f in files])
-        assert all([f._fs is fs for f in files])
-        assert sorted(str(f) for f in files) == ["/base"]
-
-
-@parameterize_fs
-@mock_aws
-def test_s3_glob3(fs_fixture):
-    with fs_fixture() as fs:
-        d2 = pathlib.Path(fs=fs)
-        files = list(d2.glob("*/0"))
-        assert 1 == len(files)
-        assert all([isinstance(f, pathlib.Path) for f in files])
-        assert all([f._fs is fs for f in files])
-        assert sorted(str(f) for f in files) == ["dir/0"]
+            expected = pathlib.PosixPath(storage, "my/library/../setup.py")
+            assert expected.absolute() == pathlib.PosixPath(
+                storage, "my/library/../setup.py"
+            )
+            assert expected.resolve() == pathlib.PosixPath(
+                storage, "my/setup.py"
+            )
+            with pytest.raises(FileNotFoundError):
+                expected.resolve(strict=True)
 
 
-@parameterize_fs
-@mock_aws
-def test_s3_glob4(fs_fixture):
-    with fs_fixture() as fs:
-        paths = ['foo', 'bar', 'baz/foo', 'baz/hoge/boom/huga']
-        for p in paths:
-            pathlib.Path(p, fs=fs).parent.mkdir(parents=True, exist_ok=True)
-            pathlib.Path(p, fs=fs).touch()
+def test_path_file(storage: str) -> None:
+    with from_url(url=storage) as fs:
+        p = Path("/my/hoge.txt", fs=fs)
+        p.touch(exist_ok=False)
+        p.touch(exist_ok=True)
+        assert p.exists()
+        assert p.is_file()
 
-        d3 = pathlib.Path('baz', fs=fs)
-        files = list(d3.glob('**/huga'))
-        assert 1 == len(files)
-        assert all([isinstance(f, pathlib.Path) for f in files])
-        assert all([f._fs is fs for f in files])
-        assert ['baz/hoge/boom/huga'] == [str(f) for f in files]
+        p.unlink(missing_ok=False)
+        p.unlink(missing_ok=True)
+        assert not p.exists()
+
+        assert p.write_bytes(b"hello binary world") == len(
+            b"hello binary world"
+        )
+        assert p.read_bytes() == b"hello binary world"
+
+        assert p.write_text("hello world") == len("hello world")
+        assert p.read_text() == "hello world"
+
+        q = Path("/my/library/hoge.txt", fs=fs)
+        old_data = q.read_bytes()
+        p.rename(q)
+        assert not p.exists()
+        assert q.read_bytes() != old_data
+
+        p = Path("/my/library.tar.gz", fs=fs)
+        old_data = p.read_bytes()
+        q.replace(p)
+        assert not q.exists()
+        assert p.read_bytes() != old_data
+
+
+def test_path_directory(storage: str) -> None:
+    with from_url(url=storage) as fs:
+        p = Path("my/local", fs=fs)
+        assert not p.exists()
+        assert not p.is_dir()
+
+        p.mkdir(parents=False, exist_ok=False)
+        p.mkdir(parents=False, exist_ok=True)
+
+        # FIXME: `S3.makedirs` not creates zero-length object.
+        dummy = p / "dummy"
+        dummy.write_bytes(b"dummy data")
+        assert p.exists()
+        assert p.is_dir()
+
+        dummy.unlink()
+        p.rmdir()
+        assert not p.is_dir()
+
+        if _has_directory_feature(p._fs):
+            with pytest.raises(NotADirectoryError):
+                p.rmdir()
+
+            with pytest.raises(NotADirectoryError):
+                Path("my/library/hoge.txt", fs=fs).rmdir()
+
+        p = Path("my/library", fs=fs)
+
+        q = p.rename("my/local")
+        assert str(q) == "my/local"
+        assert (q / "setup.py").exists()
+
+        assert q.exists()
+        assert not p.exists()
+        assert q.is_dir()
+        assert not p.is_dir()
+
+        p = Path("my/local", fs=fs)
+        q = p.replace("my/library")
+        assert str(q) == "my/library"
+        assert (q / "setup.py").exists()
+
+        assert q.exists()
+        assert not p.exists()
+        assert q.is_dir()
+        assert not p.is_dir()
+
+
+@pytest.mark.parametrize("pattern", ["my/**/*", "my/**/*.py"])
+def test_path_glob(storage: str, pattern: str) -> None:
+    with from_url(url=storage) as fs:
+        actual = Path(fs=fs)
+
+        expected_entries = [
+            "my",
+            "my/library",
+            "my/library/zoo",
+            "my/foo",
+            "my/foo/bar",
+            "my/library/zoo/abc.txt",
+            "my/foo/bar/README.md",
+            "my/library/setup.py",
+            "my/library/hoge.txt",
+            "my/foo/zoo",
+            "my/library.tar.gz",
+        ]
+        _pattern = pattern.replace("**/*", "*")
+        expected_entries = list(
+            filter(lambda x: fnmatch(x, _pattern), expected_entries)
+        )
+        actual_entries = list(map(str, actual.glob(pattern)))
+        assert sorted(actual_entries) == sorted(expected_entries)
+
+
+@pytest.mark.parametrize("pattern", ["*", "*.py"])
+def test_path_rglob(storage: str, pattern: str) -> None:
+    with from_url(url=storage) as fs:
+        actual = Path(fs=fs)
+
+        expected_entries = [
+            "my",
+            "my/library",
+            "my/library/zoo",
+            "my/foo",
+            "my/foo/bar",
+            "my/library/zoo/abc.txt",
+            "my/foo/bar/README.md",
+            "my/library/setup.py",
+            "my/library/hoge.txt",
+            "my/foo/zoo",
+            "my/library.tar.gz",
+        ]
+        expected_entries = list(
+            filter(lambda x: fnmatch(x, pattern), expected_entries)
+        )
+        actual_entries = list(map(str, actual.rglob(pattern)))
+        assert sorted(actual_entries) == sorted(expected_entries)
+
+
+@pytest.mark.parametrize("path", ["my", "my/library", "."])
+def test_path_iterdir(storage: str, path: str) -> None:
+    with from_url(url=storage) as fs:
+        actual = Path(path, fs=fs)
+
+        expected_entries = [
+            "my",
+            "my/library",
+            "my/library/zoo",
+            "my/foo",
+            "my/foo/bar",
+            "my/library/zoo/abc.txt",
+            "my/foo/bar/README.md",
+            "my/library/setup.py",
+            "my/library/hoge.txt",
+            "my/foo/zoo",
+            "my/library.tar.gz",
+        ]
+
+        filtered: list[str] = []
+        for item in expected_entries:
+            if (
+                pathlib.PurePosixPath(item).parent.parts
+                == pathlib.PurePosixPath(path).parts
+            ):
+                filtered.append(item)
+
+        actual_entries = list(map(str, actual.iterdir()))
+        assert sorted(actual_entries) == sorted(filtered)
+
+
+def test_unlink(storage: str) -> None:
+    with from_url(url=storage) as fs:
+        target = Path("my", fs=fs)
+
+        assert len(list(target.iterdir())) > 0
+
+        unlink(target)
+        assert not target.exists()
+        assert not target.is_dir()
+
+        with pytest.raises(NotADirectoryError):
+            next(target.iterdir())
+
+        for entry in target.rglob("*"):
+            print(entry)
+
+        assert len(list(target.rglob("*"))) == 0

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -665,3 +665,85 @@ def test_unlink(storage: str) -> None:
             print(entry)
 
         assert len(list(target.rglob("*"))) == 0
+
+
+def test_not_implemented(storage: str) -> None:
+    with pytest.raises(NotImplementedError):
+        Path.cwd()
+
+    with pytest.raises(NotImplementedError):
+        Path.home()
+
+    with from_url(url=storage) as fs:
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).cwd()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).home()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).stat(follow_symlinks=False)
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).chmod(mode=0o777)
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).exists(follow_symlinks=False)
+
+        with pytest.raises(NotImplementedError):
+            Path("~user", fs=fs).expanduser()
+
+        with pytest.raises(NotImplementedError):
+            next(Path(".", fs=fs).glob("*", case_sensitive=True))
+
+        with pytest.raises(NotImplementedError):
+            next(Path(".", fs=fs).glob("*", case_sensitive=False))
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).group()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_mount()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_symlink()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_socket()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_fifo()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_block_device()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_char_device()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).is_mount()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).walk()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).lchmod(mode=0o777)
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).lstat()
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).owner()
+
+        with pytest.raises(NotImplementedError):
+            p = Path("my/library.tar.gz", fs=fs)
+            p.samefile(p)
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).symlink_to(
+                "/tmp/symlink-test",
+                target_is_directory=True,
+            )
+
+        with pytest.raises(NotImplementedError):
+            Path(".", fs=fs).hardlink_to("/tmp/hardlink-test")


### PR DESCRIPTION
This PR improves compatibility between `pfio.v2.pathlib.Path` and `pathlib.Path`.

The key differences between this PR and current impl./`pathlib.Path` as follows.

- many methods raise `NotImplementedError` because they require unsupported features of `FS`
- provides `scheme` property for `as_uri` (will move to `FS`)
- `as_uri` returns `file`, `s3`, `hdfs` or custom scheme URI dependent on `fs` and `scheme`
- `stat` returns `pfio.v2.FileStat` instead of `os.stat_result`