### PR TITLE
update: moto v5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     package_data={'pfio': package_data},
     extras_require={
-        'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto[server]', 'numpy', 'mypy'],
+        'test': ['pytest', 'flake8', 'autopep8', 'parameterized', 'isort', 'moto[server]>=5.0.0', 'numpy', 'mypy'],
         # When updating doc deps, docs/requirements.txt should be updated too
         'doc': ['sphinx', 'sphinx_rtd_theme'],
         'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],

--- a/tests/v2_tests/test_custom_scheme.py
+++ b/tests/v2_tests/test_custom_scheme.py
@@ -1,11 +1,11 @@
 import os
 
-from moto import mock_s3
+from moto import mock_aws
 
 import pfio
 
 
-@mock_s3
+@mock_aws
 def test_ini():
     try:
         prev = os.getenv('PFIO_CONFIG_PATH')
@@ -31,7 +31,7 @@ def test_ini():
             assert not os.getenv('PFIO_CONFIG_PATH')
 
 
-@mock_s3
+@mock_aws
 def test_add_custom_scheme():
     pfio.v2.config._load_config()
 

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 from parameterized import parameterized
 
 from pfio.testing import ZipForTest, randstring
@@ -30,7 +30,7 @@ def gen_fs(target):
 
 
 @parameterized.expand(["s3", "local"])
-@mock_s3
+@mock_aws
 def test_smoke(target):
     filename = randstring()
     filename2 = randstring()
@@ -155,7 +155,7 @@ def test_from_url_force_type():
 
 
 @parameterized.expand(["s3", "local"])
-@mock_s3
+@mock_aws
 def test_seekeable_read(target):
     filename = randstring()
     content = b'0123456789'
@@ -185,7 +185,7 @@ class DummyLoader:
             assert self.content == fp.read()
 
 
-@mock_s3
+@mock_aws
 def test_recreate():
     content = b'deadbeef'
     # TODO: test with hdfs?

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -5,7 +5,7 @@ import io
 import tempfile
 import zipfile
 
-from moto import mock_s3
+from moto import mock_aws
 from parameterized import parameterized
 from test_fs import gen_fs
 
@@ -34,7 +34,7 @@ def test_normpath_local():
                 )
 
 
-@mock_s3
+@mock_aws
 def test_normpath_s3():
     bucket = "test-dummy-bucket"
     with from_url("s3://{}".format(bucket), create_bucket=True) as fs:
@@ -60,7 +60,7 @@ def test_normpath_s3():
 
 
 @parameterized.expand(["s3", "local"])
-@mock_s3
+@mock_aws
 def test_httpcache_simple(target):
     filename = "testfile"
     content = b"deadbeef"
@@ -120,7 +120,7 @@ def test_httpcache_too_large():
 
 
 @parameterized.expand(["s3", "local"])
-@mock_s3
+@mock_aws
 def test_httpcache_zipfile_flat(target):
     zipfilename = "test.zip"
     filename1 = "testfile1"
@@ -162,7 +162,7 @@ def test_httpcache_zipfile_flat(target):
 
 
 @parameterized.expand(["s3", "local"])
-@mock_s3
+@mock_aws
 def test_httpcache_zipfile_archived(target):
     zipfilename = "test.zip"
     filename1 = "testfile1"

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -2,7 +2,7 @@ import contextlib
 import tempfile
 
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 
 from pfio.v2 import S3, Local, from_url, pathlib
 
@@ -68,7 +68,7 @@ def test_root():
     assert pathlib.Path('a', '/b', 'c').root == '/'
 
 
-@mock_s3
+@mock_aws
 def test_s3():
     bucket = "test-dummy-bucket"
     key = "it's me!deadbeef"
@@ -154,7 +154,7 @@ parameterize_fs = pytest.mark.parametrize(
 
 
 @parameterize_fs
-@mock_s3
+@mock_aws
 def test_s3_iterdir(fs_fixture):
     with fs_fixture() as fs:
         d = pathlib.Path(fs=fs)
@@ -166,7 +166,7 @@ def test_s3_iterdir(fs_fixture):
 
 
 @parameterize_fs
-@mock_s3
+@mock_aws
 def test_s3_glob1(fs_fixture):
     with fs_fixture() as fs:
         d = pathlib.Path(fs=fs)
@@ -178,7 +178,7 @@ def test_s3_glob1(fs_fixture):
 
 
 @parameterize_fs
-@mock_s3
+@mock_aws
 def test_s3_glob2(fs_fixture):
     with fs_fixture() as fs:
         if isinstance(fs, Local):
@@ -193,7 +193,7 @@ def test_s3_glob2(fs_fixture):
 
 
 @parameterize_fs
-@mock_s3
+@mock_aws
 def test_s3_glob3(fs_fixture):
     with fs_fixture() as fs:
         d2 = pathlib.Path(fs=fs)
@@ -205,7 +205,7 @@ def test_s3_glob3(fs_fixture):
 
 
 @parameterize_fs
-@mock_s3
+@mock_aws
 def test_s3_glob4(fs_fixture):
     with fs_fixture() as fs:
         paths = ['foo', 'bar', 'baz/foo', 'baz/hoge/boom/huga']

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -5,7 +5,7 @@ import pickle
 import tempfile
 
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 
 from pfio.v2 import S3, from_url, open_url
 from pfio.v2.s3 import _ObjectReader
@@ -14,10 +14,10 @@ from pfio.v2.s3 import _ObjectReader
 @pytest.fixture
 def s3_fixture():
     # A test fixture which provides
-    # - S3 mock. using this fixture is equivalent to using @mock_s3 decorator
+    # - S3 mock. using this fixture is equivalent to using @mock_aws decorator
     # - Dummy credentials
     # - S3 filesystem with bucket creation
-    with mock_s3():
+    with mock_aws():
         class _S3Fixture():
             bucket = "test-bucket"
             aws_kwargs = {

--- a/tests/v2_tests/test_s3_zip.py
+++ b/tests/v2_tests/test_s3_zip.py
@@ -7,14 +7,14 @@ import traceback
 import zipfile
 
 import pytest
-from moto import mock_s3, server
+from moto import mock_aws, server
 
 import pfio
 from pfio.testing import ZipForTest
 from pfio.v2 import S3, Zip, from_url
 
 
-@mock_s3
+@mock_aws
 @pytest.mark.parametrize("local_cache", [False, True])
 def test_s3_zip(local_cache):
     with tempfile.TemporaryDirectory() as d:
@@ -61,7 +61,7 @@ def test_s3_zip(local_cache):
 
 @pytest.mark.parametrize("mp_start_method", ["fork", "forkserver"])
 def test_s3_zip_mp(mp_start_method):
-    # mock_s3 doesn't work well in forkserver, thus we use server-mode moto
+    # mock_aws doesn't work well in forkserver, thus we use server-mode moto
     address = "127.0.0.1"
     port = 0  # auto-selection
     moto_server = server.ThreadedMotoServer(
@@ -147,7 +147,7 @@ def s3_zip_mp_child(q, zfs, worker_idx,
         q.put(('ng', e))
 
 
-@mock_s3
+@mock_aws
 def test_force_type2():
     with tempfile.TemporaryDirectory() as d:
         zipfilename = os.path.join(d, "test.zip")


### PR DESCRIPTION
`moto` version 5 renames `moto.mock_s3` to `moto.mock_aws`.
https://docs.getmoto.org/en/latest/docs/getting_started.html