### PR TITLE
Support PPE profiling for `Local`

### DIFF
--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -17,3 +17,35 @@ A. Default buffer size of file objects from ``pfio.v2.S3`` is 16MB,
    with open_url('s3://bucket/very-large-file', 'wb') as dst:
      with open('very-large-local-file', 'rb') as src:
        shutil.copyfileobj(src, dst, length=16*1024*1024)
+
+Q. How to output tracer results (readable by Chrome Tracing).
+=============================================================
+
+A. As shown in the sample program below,
+   by executing `initialize_writer()` and `flush()` after tracing,
+   JSON that can be read by Chrome tracing can be output.
+
+.. code-block:: python
+
+   import json
+   import pytorch_pfn_extras as ppe
+
+   from pfio.v2 import Local, Path, from_url
+
+   tracer = ppe.profiler.get_tracer()
+
+   with Local(trace=True) as fs:
+     for f in fs.list():
+       if fs.isdir(f.strip()):
+         dir += 1
+         continue
+            
+       fil += 1
+       len(fs.open(f).read())
+
+   w = ppe.writing.SimpleWriter(out_dir="")
+
+   # output '['
+   tracer.initialize_writer("trace.json", w)
+   # output json dump
+   tracer.flush("trace.json", w)

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,3 +20,6 @@ ignore_missing_imports = True
 
 [mypy-pyarrow.*]
 ignore_missing_imports = True
+
+[mypy-pytorch_pfn_extras.*]
+ignore_missing_imports = True

--- a/pfio/v2/_profiler.py
+++ b/pfio/v2/_profiler.py
@@ -1,0 +1,21 @@
+try:
+    from pytorch_pfn_extras.profiler import record, record_iterable
+
+except ImportError:
+
+    class _DummyRecord:
+        def __init__(self):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            pass
+
+    # IF PPE is not available, wrap with noop
+    def record(tag, trace, *args):  # type: ignore # NOQA
+        return _DummyRecord()
+
+    def record_iterable(tag, iter, trace, *args):   # type: ignore # NOQA
+        yield from iter

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -10,12 +10,12 @@ try:
 except ImportError:
 
     # IF PPE is not available, wrap with noop
-    def record_function(*args):
+    def record_function(*args): # type: ignore
         def wrapper(f):
             return f
         return wrapper
 
-    def record_iterable(tag, iter, *args):
+    def record_iterable(tag, iter, *args): # type: ignore
         yield from iter
 
 

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -160,23 +160,28 @@ class Local(FS):
         path = os.path.join(self.cwd, path)
         return os.path.isdir(path)
 
+    @record_function("local-mkdir")
     def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
         path = os.path.join(self.cwd, file_path)
         return os.mkdir(path, mode, *args, dir_fd=None)
 
+    @record_function("local-makedirs")
     def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
         path = os.path.join(self.cwd, file_path)
         return os.makedirs(path, mode, exist_ok)
 
+    @record_function("local-exists")
     def exists(self, file_path: str):
         path = os.path.join(self.cwd, file_path)
         return os.path.exists(path)
 
+    @record_function("local-rename")
     def rename(self, src, dst):
         s = os.path.join(self.cwd, src)
         d = os.path.join(self.cwd, dst)
         return os.rename(s, d)
 
+    @record_function("local-remove")
     def remove(self, file_path: str, recursive=False):
         file_path = os.path.join(self.cwd, file_path)
         if recursive:
@@ -186,6 +191,7 @@ class Local(FS):
 
         return os.remove(file_path)
 
+    @record_function("local-glob")
     def glob(self, pattern: str):
         return [
             str(item.relative_to(self.cwd))

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -8,7 +8,7 @@ try:
     from pytorch_pfn_extras.profiler import record_function, record_iterable
 
 except ImportError:
-    print("no ppe")
+
     # IF PPE is not available, wrap with noop
     def record_function(*args):
         def wrapper(f):

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -4,29 +4,7 @@ import pathlib
 import shutil
 from typing import Optional
 
-try:
-    from pytorch_pfn_extras.profiler import record, record_iterable
-
-except ImportError:
-
-    class _DummyRecord:
-        def __init__(self):
-            pass
-
-        def __enter__(self):
-            pass
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            pass
-
-    # IF PPE is not available, wrap with noop
-    def record(tag, trace, *args):  # type: ignore # NOQA
-        return _DummyRecord()
-
-    def record_iterable(tag, iter, trace, *args):   # type: ignore # NOQA
-        yield from iter
-
-
+from ._profiler import record, record_iterable
 from .fs import FS, FileStat, format_repr
 
 

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -99,7 +99,7 @@ class Local(FS):
             },
         )
 
-    @record_function("local-open")
+    @record_function("pfio.v2.Local:open")
     def open(self, file_path, mode='r',
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):
@@ -111,7 +111,7 @@ class Local(FS):
 
     def list(self, path: Optional[str] = '', recursive=False,
              detail=False):
-        for e in record_iterable("local-list",
+        for e in record_iterable("pfio.v2.Local:list",
                                  self._list(path, recursive, detail)):
             yield e
 
@@ -151,7 +151,7 @@ class Local(FS):
                 yield from self._recursive_list(prefix_end_index,
                                                 e.path, detail)
 
-    @record_function("local-stat")
+    @record_function("pfio.v2.Local:stat")
     def stat(self, path):
         path = os.path.join(self.cwd, path)
         return LocalFileStat(os.stat(path), path)
@@ -160,28 +160,28 @@ class Local(FS):
         path = os.path.join(self.cwd, path)
         return os.path.isdir(path)
 
-    @record_function("local-mkdir")
+    @record_function("pfio.v2.Local:mkdir")
     def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
         path = os.path.join(self.cwd, file_path)
         return os.mkdir(path, mode, *args, dir_fd=None)
 
-    @record_function("local-makedirs")
+    @record_function("pfio.v2.Local:makedirs")
     def makedirs(self, file_path: str, mode=0o777, exist_ok=False):
         path = os.path.join(self.cwd, file_path)
         return os.makedirs(path, mode, exist_ok)
 
-    @record_function("local-exists")
+    @record_function("pfio.v2.Local:exists")
     def exists(self, file_path: str):
         path = os.path.join(self.cwd, file_path)
         return os.path.exists(path)
 
-    @record_function("local-rename")
+    @record_function("pfio.v2.Local:rename")
     def rename(self, src, dst):
         s = os.path.join(self.cwd, src)
         d = os.path.join(self.cwd, dst)
         return os.rename(s, d)
 
-    @record_function("local-remove")
+    @record_function("pfio.v2.Local:remove")
     def remove(self, file_path: str, recursive=False):
         file_path = os.path.join(self.cwd, file_path)
         if recursive:
@@ -191,7 +191,7 @@ class Local(FS):
 
         return os.remove(file_path)
 
-    @record_function("local-glob")
+    @record_function("pfio.v2.Local:glob")
     def glob(self, pattern: str):
         return [
             str(item.relative_to(self.cwd))

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -5,17 +5,18 @@ import shutil
 from typing import Optional
 
 try:
-    from pytorch_pfn_extras.profiler import record_function, record_iterable
+    from pytorch_pfn_extras.profiler import (  # type: ignore # NOQA
+        record_function, record_iterable)
 
 except ImportError:
 
     # IF PPE is not available, wrap with noop
-    def record_function(*args): # type: ignore # NOQA
+    def record_function(*args):  # type: ignore # NOQA
         def wrapper(f):
             return f
         return wrapper
 
-    def record_iterable(tag, iter, *args): # type: ignore # NOQA
+    def record_iterable(tag, iter, *args):   # type: ignore # NOQA
         yield from iter
 
 

--- a/pfio/v2/local.py
+++ b/pfio/v2/local.py
@@ -10,12 +10,12 @@ try:
 except ImportError:
 
     # IF PPE is not available, wrap with noop
-    def record_function(*args): # type: ignore
+    def record_function(*args): # type: ignore # NOQA
         def wrapper(f):
             return f
         return wrapper
 
-    def record_iterable(tag, iter, *args): # type: ignore
+    def record_iterable(tag, iter, *args): # type: ignore # NOQA
         yield from iter
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'doc': ['sphinx', 'sphinx_rtd_theme'],
         'bench': ['numpy>=1.19.5', 'torch>=1.9.0', 'Pillow<=8.2.0'],
         'hdfs': ['pyarrow>=6.0.0'],
+        'trace': ['pytorch-pfn-extras'],
     },
     # When updating install requires, docs/requirements.txt should be updated too
     install_requires=['boto3', 'deprecation', 'urllib3'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py38,py39,py310,py311,py312,doc
 
 [testenv]
-deps = .[test]
+deps = .[test, trace]
 skipsdist = True
 commands =
         flake8 pfio tests


### PR DESCRIPTION
This PR resolves the `Local` task in #258 

> [!NOTE]
> To enable tracing, `trace=True` must be added during `Local()` initialization (or `from_url()`).

Sample program to check tracing
```python
import json
import pytorch_pfn_extras as ppe

from pfio.v2 import Local, Path, from_url

@ppe.profiler.record_function("my_tag_2", trace=True)
def my_run2(x):
    pass

def my_run1(x):
    pass

def p():
    tracer = ppe.profiler.get_tracer()

    tracer.clear()
    with ppe.profiler.record("my_tag_1", trace=True):
        my_run1('hoge')

    for i in range(4):
        my_run2("far")

    dir = 0
    fil = 0
    with Local(trace=True) as fs:
        for f in fs.list():
            if fs.isdir(f.strip()):
                dir += 1
                continue
            
            fil += 1
            len(fs.open(f).read())

    print(fil, "files", dir, "dirs")

    dict = tracer.state_dict()
    keys = [event["name"] for event in json.loads(dict["_event_list"])]
    print(keys)

    w = ppe.writing.SimpleWriter(out_dir="")

    # output '['
    tracer.initialize_writer("trace.json", w)
    # output json dump
    tracer.flush("trace.json", w)

p()
```

output
```
9 files 15 dirs
['my_tag_1', 'my_tag_2', 'my_tag_2', 'my_tag_2', 'my_tag_2', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-0', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-1', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-2', 'pfio.v2.Local:list-3', 'pfio.v2.Local:list-4', 'pfio.v2.Local:list-5', 'pfio.v2.Local:list-6', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-7', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-8', 'pfio.v2.Local:list-9', 'pfio.v2.Local:list-10', 'pfio.v2.Local:list-11', 'pfio.v2.Local:list-12', 'pfio.v2.Local:list-13', 'pfio.v2.Local:list-14', 'pfio.v2.Local:list-15', 'pfio.v2.Local:list-16', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-17', 'pfio.v2.Local:list-18', 'pfio.v2.Local:list-19', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-20', 'pfio.v2.Local:list-21', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-22', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:list-23']
```

drawing of the output json file (`trace.json`) with `chrome://tracing` is shown below
![image](https://github.com/user-attachments/assets/307a28e1-4311-42d2-bc62-303193f4ea59)