### PR TITLE
Make `botocore.config.Config.{connect,read}_timeout` configurable

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -305,6 +305,7 @@ class S3(FS):
     whichever smaller.
     ``buffering=0`` disables buffering, and ``buffering>0`` forcibly sets the
     specified value as the buffer size in bytes.
+    ``connect_timeout`` and ``read_timeout`` are passed as ``botocore.config``.
     '''
 
     def __init__(self, bucket, prefix=None,

--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import Optional, Type
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from .fs import FS, FileStat, format_repr
@@ -313,6 +314,8 @@ class S3(FS):
                  mpu_chunksize=32*1024*1024,
                  buffering=-1,
                  create=False,
+                 connect_timeout=None,
+                 read_timeout=None,
                  _skip_connect=None,  # For test purpose
                  **_):
         super().__init__()
@@ -347,6 +350,13 @@ class S3(FS):
             kwargs['aws_secret_access_key'] = os.path.expandvars(
                 aws_secret_access_key)
 
+        botocore_config = {}
+        if connect_timeout is not None:
+            botocore_config['connect_timeout'] = int(connect_timeout)
+        if read_timeout is not None:
+            botocore_config['read_timeout'] = int(read_timeout)
+        self.botocore_config = botocore_config
+
         # We won't expect any enviroment variable for S3 endpoints
         # supported by boto3. Instead, we take S3_ENDPOINT in case
         # argument ``endpoint`` is not given. Otherwise, it goes to
@@ -380,7 +390,8 @@ class S3(FS):
 
     def _connect(self):
         # print('boto3.client options:', kwargs)
-        self.client = boto3.client('s3', **self.kwargs)
+        config = Config(**self.botocore_config)
+        self.client = boto3.client('s3', config=config, **self.kwargs)
 
         try:
             self.client.head_bucket(Bucket=self.bucket)

--- a/tests/v2_tests/test_custom_scheme.py
+++ b/tests/v2_tests/test_custom_scheme.py
@@ -42,7 +42,8 @@ def test_add_custom_scheme():
         {
             "endpoint": "https://s3.example.com",
             "aws_access_key_id": "hoge",
-            "aws_secret_access_key": os.environ["HOME"]
+            "aws_secret_access_key": os.environ["HOME"],
+            "read_timeout": "120",
         },
     )
 
@@ -52,6 +53,7 @@ def test_add_custom_scheme():
         "endpoint": "https://s3.example.com",
         "aws_access_key_id": "hoge",
         "aws_secret_access_key": os.environ["HOME"],
+        "read_timeout": "120",
     } == pfio.v2.config.get_custom_scheme("baz2")
 
     with pfio.v2.from_url('foobar2://pfio/') as fs:
@@ -63,3 +65,4 @@ def test_add_custom_scheme():
         assert 'https://s3.example.com' == s3.kwargs['endpoint_url']
         assert 'hoge' == s3.kwargs['aws_access_key_id']
         assert os.getenv('HOME') == s3.kwargs['aws_secret_access_key']
+        assert 120 == s3.botocore_config['read_timeout']

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -84,6 +84,15 @@ def test_s3_files(s3_fixture):
         assert not s3.isdir("/bas")
 
 
+def test_s3_init_with_timeouts(s3_fixture):
+    with from_url('s3://test-bucket/base',
+                  connect_timeout=300,
+                  read_timeout=120) as s3:
+        assert isinstance(s3, S3)
+        assert (s3.botocore_config['connect_timeout'] == 300)
+        assert (s3.botocore_config['read_timeout'] == 120)
+
+
 # TODO: Find out a way to know buffer size used in a BufferedReader
 @pytest.mark.parametrize("buffering, reader_type",
                          [(-1, io.BufferedReader),


### PR DESCRIPTION
Allow users to configure `botocore.{connect,read}_timeout` in `pfio.v2.S3`. Support both the ways via the custom scheme or via directly passing the initializer (`from_url`, `pfio.v2.S3`) like the below:

**a) via the custom scheme**
```ini
[baz]
scheme = s3
endpoint = https://s3.example.com
aws_access_key_id=hoge
aws_secret_access_key=$HOME
connect_timeout=300
read_timeout=120
```

**b) via the initializer (`from_url`)** ... from a test code
```python
def test_s3_init_with_timeouts(s3_fixture):
    with from_url('s3://test-bucket/base',
                  connect_timeout=300,
                  read_timeout=120) as s3:
        assert isinstance(s3, S3)
        assert (s3.botocore_config['connect_timeout'] == 300)
        assert (s3.botocore_config['read_timeout'] == 120)
```