### PR TITLE
Support PPE profiling for `Zip`

### DIFF
--- a/pfio/v2/zip.py
+++ b/pfio/v2/zip.py
@@ -100,13 +100,15 @@ class Zip(FS):
         self._reset()
 
     def _reset(self):
-        obj = self.backend.open(self.file_path,
-                                self.mode + 'b',
-                                **self.kwargs)
-        self.fileobj = obj
+        with record("pfio.v2.Zip:create-zipfile-obj", trace=self.trace):
+            obj = self.backend.open(self.file_path,
+                                    self.mode + 'b',
+                                    **self.kwargs)
+            self.fileobj = obj
 
-        assert self.fileobj is not None
-        self.zipobj = zipfile.ZipFile(self.fileobj, self.mode)
+            assert self.fileobj is not None
+            self.zipobj = zipfile.ZipFile(self.fileobj, self.mode)
+
         self.name_cache: Optional[Set[str]] = None
         if self._readonly:
             self.name_cache = self._names()


### PR DESCRIPTION
This PR resolves the `Zip` task in #258 

Sample program to check tracing

```python
import json
import pytorch_pfn_extras as ppe

from pfio.v2 import Local, Path, from_url
from pfio.testing import ZipForTest


def p():
    tracer = ppe.profiler.get_tracer()
    tracer.clear()

    zipfilename = "test.zip"
    data = dict(
        foo = b'foo',
        bar = b'bar',
        foobar = b'foobar',
    )
    file = ZipForTest(zipfilename, data)

    with from_url(zipfilename, trace=True) as fs:
        for name in fs.list(recursive=True):
            with fs.open(name, mode='rb') as fp:
                tmp = fp.read()
                assert file.content(name) == tmp

    state = tracer.state_dict()
    keys = [event["name"] for event in json.loads(state["_event_list"])]
    print(keys)

    w = ppe.writing.SimpleWriter(out_dir="")
    tracer.initialize_writer("trace_zip.json", w)
    tracer.flush("trace_zip.json", w)


p()
```

output

```
['pfio.v2.Local:open', 'pfio.v2.Local:seek', 'pfio.v2.Local:tell', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Zip:create-zipfile-obj', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Local:seekable', 'pfio.v2.Zip:open', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Zip:read', 'pfio.v2.Zip:exit-context', 'pfio.v2.Zip:list-0', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Local:seekable', 'pfio.v2.Zip:open', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Zip:read', 'pfio.v2.Zip:exit-context', 'pfio.v2.Zip:list-1', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Local:seekable', 'pfio.v2.Zip:open', 'pfio.v2.Local:seek', 'pfio.v2.Local:read', 'pfio.v2.Local:tell', 'pfio.v2.Zip:read', 'pfio.v2.Zip:exit-context', 'pfio.v2.Zip:list-2', 'pfio.v2.Local:close', 'pfio.v2.Zip:close']
```

rendering of the output json file (`trace_zip.json`) with chrome://tracing is shown below
![image](https://github.com/user-attachments/assets/dc7fef93-0020-4125-97da-8095f5cc49eb)