### PR TITLE
Revert "Settings for workload identity federation (gcs) (#346)"

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,10 +9,6 @@ on:
 
 jobs:
   build:
-    # Add "id-token" with the intended permissions.
-    permissions:
-      contents: 'read'
-      id-token: 'write'
 
     runs-on: ubuntu-latest
     strategy:
@@ -22,18 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - uses: 'google-github-actions/auth@v2'
-      with:
-        project_id: 'cluster-storage'
-        workload_identity_provider: 'projects/1097862457753/locations/global/workloadIdentityPools/github-actions-pfio-ci-tasks/providers/github'
-        service_account: 'pfio-github-actions@cluster-storage.iam.gserviceaccount.com'
-    - name: 'Set up Google Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
-    - name: 'Check Bucket accessibility'
-      run: |
-        gcloud storage ls gs://pfn-pfio-test-bucket/ --recursive
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ dist
 .tox
 
 *~
-
-# Ignore generated credentials from google-github-actions/auth
-gha-creds-*.json


### PR DESCRIPTION
This reverts commit c4dff7cd3927cef40ae100787c5d1c60546711f5.

The CI invoked from external collaborators is failing, and we need to carefully redesign the CI and driver implementation, so we will revert the CI support for GCS once.