### PR TITLE
update max line length

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py38,py39,py310,py311,py312,doc
 deps = .[test, trace]
 skipsdist = True
 commands =
-        flake8 pfio tests
+        flake8 --max-line-length=200 pfio tests
         autopep8 -r pfio tests --diff
         isort . --check --diff
         mypy pfio


### PR DESCRIPTION
relax the line length restriction as the implementation of the profiler often leads to deep indent