### PR TITLE
Drop Python 3.8 as of PEP-569

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ learning training with batteries included. It supports
 ## Dependency
 
 - HDFS client and libhdfs for HDFS access
-- CPython >= 3.8
+- CPython >= 3.9
 
 ## Installation and Document build
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: POSIX :: Linux',
 
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,doc
+envlist = py39,py310,py311,py312,doc
 
 [testenv]
 deps = .[test, trace]


### PR DESCRIPTION
Addresses: https://github.com/pfnet/pfio/issues/310