### PR TITLE
Support PPE profiling for HTTPCache / HTTPCachedFS

### DIFF
--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -299,7 +299,8 @@ class MultiprocessFileCache(cache.Cache):
 
             index_entry = pack('Qq', data_pos, len(data))
             with record("pfio.cache.multiprocessfile:put:write_index", trace=self.trace):
-                assert os.pwrite(self.cache_fd, index_entry, index_ofst) == self.buflen
+                assert os.pwrite(self.cache_fd, index_entry,
+                                 index_ofst) == self.buflen
             with record("pfio.cache.multiprocessfile:put:write_data", trace=self.trace):
                 assert os.pwrite(self.cache_fd, data, data_pos) == len(data)
             with record("pfio.cache.multiprocessfile:put:sync", trace=self.trace):

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -156,7 +156,7 @@ class FS(abc.ABC):
         return self.pid != os.getpid()
 
     @property
-    def is_trace(self):
+    def is_traced(self):
         assert hasattr(self, 'trace')
         return self.trace
 

--- a/pfio/v2/fs.py
+++ b/pfio/v2/fs.py
@@ -90,6 +90,7 @@ class FS(abc.ABC):
 
     def __init__(self):
         self.pid = os.getpid()
+        self.trace = False
 
     @property
     def cwd(self):
@@ -153,6 +154,11 @@ class FS(abc.ABC):
     def is_forked(self):
         assert hasattr(self, 'pid')
         return self.pid != os.getpid()
+
+    @property
+    def is_trace(self):
+        assert hasattr(self, 'trace')
+        return self.trace
 
     def close(self) -> None:
         pass

--- a/pfio/v2/http_cache.py
+++ b/pfio/v2/http_cache.py
@@ -54,7 +54,7 @@ class HTTPCachedFS(FS):
         super().__init__()
 
         self.fs = fs
-        self.trace = self.fs.is_trace
+        self.trace = self.fs.is_traced
         self.max_cache_size = max_cache_size
         self.conn = HTTPConnector(url, bearer_token_path, trace=self.trace)
         if url.endswith("/"):
@@ -129,7 +129,7 @@ class _HTTPCacheIOBase(io.RawIOBase):
         self.whole_file: Optional[bytes] = None
         self.pos: Optional[int] = None
         self.fp: Optional[io.RawIOBase] = None
-        self.trace = self.fs.is_trace
+        self.trace = self.fs.is_traced
 
         self._closed = False
 

--- a/tests/v2_tests/test_http_cache.py
+++ b/tests/v2_tests/test_http_cache.py
@@ -2,15 +2,17 @@
 # TODO: test with hdfs?
 
 import io
+import json
 import tempfile
 import zipfile
 
+import pytest
 from moto import mock_aws
 from parameterized import parameterized
 from test_fs import gen_fs
 
 from pfio.testing import make_http_server
-from pfio.v2 import HTTPCachedFS, from_url
+from pfio.v2 import HTTPCachedFS, Local, from_url
 
 
 def test_normpath_local():
@@ -201,3 +203,36 @@ def test_httpcache_zipfile_archived(target):
                     assert fp.read(-1) == filecontent1
                 with archive.open(filename2) as fp:
                     assert fp.read(-1) == filecontent2
+
+
+def test_httpcache_profiling():
+    ppe = pytest.importorskip("pytorch_pfn_extras")
+    ppe.profiler.clear_tracer()
+
+    filename = "testfile"
+    content = b"abcdabcd"
+
+    with make_http_server() as (httpd, port), tempfile.TemporaryDirectory() as tmpdir:
+        http_cache = f"http://localhost:{port}/"
+
+        with Local(tmpdir, trace=True) as local_fs:
+            fs = HTTPCachedFS(http_cache, local_fs)
+
+            with fs.open(filename, mode="wb") as fp:
+                fp.write(content)
+            with fs.open(filename, mode="rb") as fp:
+                assert fp.read(-1) == content
+
+    dict = ppe.profiler.get_tracer().state_dict()
+    keys = [event["name"] for event in json.loads(dict['_event_list'])]
+
+    assert "pfio.v2.http_cache:open" in keys
+    assert "pfio.v2.Local:open" in keys
+
+    assert "pfio.v2.http_cache:read" in keys
+    assert "pfio.v2.http_cache:load_file" in keys
+    assert "pfio.cache.http.conn:get" in keys
+    assert "pfio.cache.http.conn:get:request" in keys
+    assert "pfio.cache.http.conn:put" in keys
+    assert "pfio.cache.http.conn:put:request" in keys
+    assert "pfio.v2.Local:read" in keys


### PR DESCRIPTION
This PR resolves the `CachedHttpFs` / `HttpCache` task in #258 

Sample program to check tracing
```python
import json
import tempfile
import pytorch_pfn_extras as ppe

from pfio.v2 import HTTPCachedFS, Local
from pfio.cache import HTTPCache
from pfio.testing import make_http_server


def cache_httpcache():
    filename = "cache_httpcache.json"
    tracer = ppe.profiler.get_tracer()

    with make_http_server() as (httpd, port):
        http_cache = f"http://localhost:{port}/"
        cache = HTTPCache(1, http_cache,
                          do_pickle=True, trace=True)

        cache.put(0, b"foo")
        assert b"foo" == cache.get(0)

    dict = tracer.state_dict()
    keys = [event["name"] for event in json.loads(dict['_event_list'])]
    print(keys)

    writer = ppe.writing.SimpleWriter(out_dir="")
    tracer.initialize_writer(filename, writer)
    tracer.flush(filename, writer)


def fs_httpcache():
    filename = "fs_httpcache.json"
    tracer = ppe.profiler.get_tracer()

    local_filename = "testfile"
    content = b"abcdabcd"

    with make_http_server() as (httpd, port), tempfile.TemporaryDirectory() as tmpdir:
        http_cache = f"http://localhost:{port}/"

        with Local(tmpdir, trace=True) as local_fs:
            fs = HTTPCachedFS(http_cache, local_fs)

            with fs.open(local_filename, mode="wb") as fp:
                fp.write(content)
            with fs.open(local_filename, mode="rb") as fp:
                assert fp.read(-1) == content
            with fs.open(local_filename, mode="rb") as fp:
                assert fp.read(-1) == content

    dict = tracer.state_dict()
    keys = [event["name"] for event in json.loads(dict['_event_list'])]
    print(keys)

    writer = ppe.writing.SimpleWriter(out_dir="")
    tracer.initialize_writer(filename, writer)
    tracer.flush(filename, writer)


cache_httpcache()
fs_httpcache()
```

- HTTPCache output
```
['pfio.cache.http.conn:put:request', 'pfio.cache.http.conn:put', 'pfio.cache.http:put', 'pfio.cache.http.conn:get:request', 'pfio.cache.http.conn:get', 'pfio.cache.http:get']
```

rendering of the output json (`cache_httpcache.json`) file with chrome://tracing is shown below
![image](https://github.com/user-attachments/assets/bf725571-2af4-44d2-afc0-32424060d24d)

- HTTPCachedFS output
```
['pfio.v2.Local:open', 'pfio.v2.http_cache:open', 'pfio.v2.Local:write', 'pfio.v2.Local:exit-context', 'pfio.v2.http_cache:open', 'pfio.cache.http.conn:get:request', 'pfio.cache.http.conn:get', 'pfio.v2.Local:stat', 'pfio.v2.Local:open', 'pfio.v2.Local:read', 'pfio.v2.Local:exit-context', 'pfio.cache.http.conn:put:request', 'pfio.cache.http.conn:put', 'pfio.v2.http_cache:load_file', 'pfio.v2.http_cache:read', 'pfio.v2.http_cache:open', 'pfio.cache.http.conn:get:request', 'pfio.cache.http.conn:get', 'pfio.v2.http_cache:load_file', 'pfio.v2.http_cache:read']
```
rendering of the output json (`fs_httpcache.json`) file with chrome://tracing is shown below
![image](https://github.com/user-attachments/assets/106e0be0-9189-44a9-9ebe-626d7c0f6453)
