### PR TITLE
Fix linter warnings and test errors

### DIFF
--- a/pfio/cache/file_cache.py
+++ b/pfio/cache/file_cache.py
@@ -100,7 +100,6 @@ def _check_local(path: str):
     Raises an error if the ``stat(1)`` answers it as NFS.
 
     '''
-    global _FORCE_LOCAL
     if not _FORCE_LOCAL:
         return
 

--- a/pfio/cache/multiprocess_file_cache.py
+++ b/pfio/cache/multiprocess_file_cache.py
@@ -34,7 +34,10 @@ class _NoOpenNamedTemporaryFile(object):
 
     def close(self, unlink=os.unlink, getpid=os.getpid):
         if self.name and self.master_pid == getpid():
-            unlink(self.name)
+            try:
+                unlink(self.name)
+            except FileNotFoundError:
+                pass
             self.name = None
 
     def __del__(self):

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -564,6 +564,7 @@ class TestZipWithLargeData(unittest.TestCase):
 
         # nested zip and nested file
         self.tmpdir = tempfile.TemporaryDirectory()
+        self.zipdir = tempfile.TemporaryDirectory()
 
         # test file
         self.testfile_name = "testfile1"
@@ -572,19 +573,18 @@ class TestZipWithLargeData(unittest.TestCase):
         testfile_path = os.path.join(self.tmpdir.name, self.testfile_name)
 
         # paths used in tests
-        self.zip_file_path = self.zip_file_name + ".zip"
+        self.zip_file_path = os.path.join(self.zipdir.name, self.zip_file_name + ".zip")
 
         with open(testfile_path, "w") as tmpfile:
             tmpfile.write(self.test_string)
 
-        # this will include outside.zip itself into the zip
         make_zip(self.zip_file_path,
                  root_dir=self.tmpdir.name,
                  base_dir=".")
 
     def tearDown(self):
         self.tmpdir.cleanup()
-        local.remove(self.zip_file_path)
+        self.zipdir.cleanup()
 
     def test_read_multi_processes(self):
         barrier = multiprocessing.Barrier(2)


### PR DESCRIPTION
- remove `global _FORCE_LOCAL`
  - The `_FORCE_LOCAL` variable is read-only, making this line unnecessary.
- Handle `FileNotFoundError`
  - When `close()` explicitly deletes a file and then the garbage collector calls `close()` again, it attempts to unlink a non-existent file. This can trigger a `FileNotFoundError`, so Python 3.12 and later versions will generate a warning if this condition isn't properly handled.
- zipdir
  - This modification is only for testing purposes. Since zip files are created using relative paths from the current directory, multiple concurrent tests may cause conflicts that fail the tests. By creating temporary directories, we ensure that multiple tests running in parallel won't encounter conflicts, thereby improving test stability.

## Related issues/PRs

- https://github.com/pfnet/pfio/issues/365