### PR TITLE
Call as_uri via pathlib.Path instance in compatibility test

### DIFF
--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -407,7 +407,7 @@ def test_purepath_compatible_methods(
             assert actual.as_uri() == urlunparse(unparsed)
         else:
             with pytest.raises(ValueError):
-                expected.as_uri()
+                pathlib.Path(expected).as_uri()
 
             with pytest.raises(ValueError):
                 actual.as_uri()


### PR DESCRIPTION
`pathlib.PurePath.as_uri` is deprecated as a class-style call (it is slated to become an instance-only method around 3.19). The pathlib compatibility test invokes `expected.as_uri()` on a PurePosixPath to assert the relative-path branch raises ValueError, which now also prints a DeprecationWarning on 3.14+.

Wrap `expected` in `pathlib.Path` first so the call goes through the instance method that survives the migration. 

This is also a preparation for Python 3.14 support.

## Effect

N/A

## Related issues

- #372 