### PR TITLE
Migrate is_reserved usage to os.path.isreserved on Python 3.14+

### DIFF
--- a/pfio/v2/pathlib.py
+++ b/pfio/v2/pathlib.py
@@ -1,4 +1,5 @@
 import functools
+import os.path
 import uuid
 from fnmatch import fnmatch, fnmatchcase
 from io import IOBase
@@ -279,7 +280,14 @@ class PurePath(PathLike):
             return self._pure.is_relative_to(*other)  # type: ignore
 
     def is_reserved(self) -> bool:
-        return self._pure.is_reserved()
+        # `pathlib.PurePath.is_reserved` was deprecated in 3.13 and is
+        # removed in 3.15; the replacement `os.path.isreserved` (added
+        # in 3.14) lives only in `ntpath`, so POSIX has no successor.
+        if python_version_info.minor < 14:
+            return self._pure.is_reserved()
+        if os.name == "nt":
+            return os.path.isreserved(self._pure)  # type: ignore[attr-defined]
+        return False
 
     def joinpath(
         self: SelfPurePathType,

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -386,7 +386,12 @@ def test_purepath_compatible_methods(
 
         assert actual.as_posix() == expected.as_posix()
         assert actual.is_absolute() == expected.is_absolute()
-        assert actual.is_reserved() == expected.is_reserved()
+        if python_version_info.minor < 14:
+            assert actual.is_reserved() == expected.is_reserved()
+        elif os.name == "nt":
+            assert actual.is_reserved() == os.path.isreserved(expected)
+        else:
+            assert actual.is_reserved() is False
 
         if python_version_info.minor > 8:
             assert expected.is_relative_to(str(actual))


### PR DESCRIPTION
pathlib.PurePath.is_reserved is an deprecated method scheduled for removal in 3.15. Since it relies on the minor version check, we should modify it to use os.path.isreserved instead, as this became deprecated in version 3.13.

This also prepares the code for compatibility with 3.14.

## Effect

N/A

## Discussion

This method only checks whether a given path is a special Windows path, and since Python has removed it from the main library, it may make sense to remove it from pfio as well.


## Related issues

- #372