### PR TITLE
Adapt PurePath.relative_to to Python 3.14

### DIFF
--- a/pfio/v2/pathlib.py
+++ b/pfio/v2/pathlib.py
@@ -1,5 +1,6 @@
 import functools
 import uuid
+import warnings
 from fnmatch import fnmatch, fnmatchcase
 from io import IOBase
 from os import PathLike
@@ -275,8 +276,27 @@ class PurePath(PathLike):
             raise NotImplementedError(
                 "`is_relative_to()` supports python 3.9 or higher"
             )
-        else:
-            return self._pure.is_relative_to(*other)  # type: ignore
+
+        # Same rationale as `relative_to`: unwrap pfio PurePath so
+        # 3.14's stdlib does not skip its `PurePosixPath` coercion,
+        # and shim the multi-arg form that stdlib removed in 3.14.
+        parts = tuple(
+            o._pure if isinstance(o, PurePath) else o for o in other
+        )
+
+        if len(parts) > 1:
+            # NOTE: drop this shim (and the `*other` signature) once
+            # downstream callers have moved to a single joined path.
+            warnings.warn(
+                "passing multiple positional arguments to "
+                "pfio.v2.pathlib.PurePath.is_relative_to is deprecated; "
+                "pass a single joined path instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            parts = (PurePosixPath(*parts),)
+
+        return self._pure.is_relative_to(*parts)  # type: ignore
 
     def is_reserved(self) -> bool:
         return self._pure.is_reserved()
@@ -309,13 +329,37 @@ class PurePath(PathLike):
                 "`walk_up=True` supports python version 3.12 or higher"
             )
 
+        # Python 3.14 stdlib skips PurePosixPath coercion for objects
+        # exposing `with_segments`, which pfio's PurePath does. Unwrap
+        # to the inner stdlib path so subpath checks compare like-typed
+        # values.
+        parts = tuple(
+            o._pure if isinstance(o, PurePath) else o for o in other
+        )
+
+        if len(parts) > 1:
+            # NOTE: Python 3.14 removed the multi-arg form of
+            # PurePath.relative_to from stdlib. pfio keeps the shape
+            # here for now and joins the parts before delegating, with
+            # a DeprecationWarning so callers can migrate. Drop this
+            # shim (and the `*other` signature) once downstream has
+            # moved to a single joined path argument.
+            warnings.warn(
+                "passing multiple positional arguments to "
+                "pfio.v2.pathlib.PurePath.relative_to is deprecated; "
+                "pass a single joined path instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            parts = (PurePosixPath(*parts),)
+
         if python_version_info.minor >= 12:
             rel = self._pure.relative_to(
-                *other,
+                *parts,
                 walk_up=walk_up,  # type: ignore
             )
         else:
-            rel = self._pure.relative_to(*other)
+            rel = self._pure.relative_to(*parts)
 
         return self.with_segments(rel)
 

--- a/tests/v2_tests/test_pathlib.py
+++ b/tests/v2_tests/test_pathlib.py
@@ -336,10 +336,10 @@ def test_purepath_relative_to(temporary_storage: str) -> None:
         assert excepted.relative_to("/") == pathlib.PurePosixPath("etc/passwd")
         assert actual.relative_to("/") == PurePath("etc/passwd", fs=fs)
 
-        assert excepted.relative_to("/", "etc") == pathlib.PurePosixPath(
+        assert excepted.relative_to("/etc") == pathlib.PurePosixPath(
             "passwd"
         )
-        assert actual.relative_to("/", "etc") == PurePath("passwd", fs=fs)
+        assert actual.relative_to("/etc") == PurePath("passwd", fs=fs)
 
         excepted = pathlib.PurePosixPath("usr/local/lib")
         actual = PurePath("usr/local/lib", fs=fs)
@@ -362,6 +362,25 @@ def test_purepath_relative_to(temporary_storage: str) -> None:
             "lib/"
         )
         assert actual.relative_to("usr/local/") == PurePath("lib/", fs=fs)
+
+
+def test_purepath_relative_to_multi_arg_deprecated(
+    temporary_storage: str,
+) -> None:
+    with from_url(temporary_storage) as fs:
+        actual = PurePath("/etc/passwd", fs=fs)
+        with pytest.warns(DeprecationWarning, match="multiple positional"):
+            result = actual.relative_to("/", "etc")
+        assert result == PurePath("passwd", fs=fs)
+
+
+def test_purepath_is_relative_to_multi_arg_deprecated(
+    temporary_storage: str,
+) -> None:
+    with from_url(temporary_storage) as fs:
+        actual = PurePath("/etc/passwd", fs=fs)
+        with pytest.warns(DeprecationWarning, match="multiple positional"):
+            assert actual.is_relative_to("/", "etc")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Python 3.14 changes `pathlib.PurePath.relative_to` in two ways that break the pfio wrapper:

- The multi-arg form `relative_to(*multi)` was removed — stdlib raises TypeError. pfio's wrapper forwards `*other`, so any caller that passed multiple positional arguments (including our own tests) breaks.
- The new implementation skips `PurePosixPath` coercion for arguments that expose `with_segments`. pfio's `PurePath` defines `with_segments`, so passing a pfio Path to `relative_to` compares it against `self.parents` which remain stdlib paths; cross-type equality is always False and the subpath search raises ValueError (seen from `copy()`'s internal `entry.relative_to(src)`).

Unwrap pfio `PurePath` arguments to their inner `_pure` before delegating, so subpath checks compare like-typed values. For the removed multi-arg form, keep the public `*other` shape as a shim: join the parts into a single `PurePosixPath` and emit `DeprecationWarning` so downstream can migrate. A `NOTE:` in the wrapper flags the shim (and the `*other` signature) as future cleanup once callers have moved.

Update the existing pathlib test to use the single-arg form (the stdlib call in the same assertion would otherwise TypeError on 3.14), and add a dedicated test that exercises the shim and asserts the `DeprecationWarning`.

## Discussion

Allowing compatibility breaks would enable a simple solution of simply rejecting multiple arguments from the next pfio release.

## Related issues

- #372 
