### PR TITLE
Make multiprocessing tests forkserver-safe

### DIFF
--- a/tests/cache_tests/test_multiprocess_file_cache.py
+++ b/tests/cache_tests/test_multiprocess_file_cache.py
@@ -8,6 +8,20 @@ import pytest
 
 from pfio.cache import FileCache, MultiprocessFileCache
 
+_CONSISTENCY_N_SAMPLES_PER_WORKER = 1024
+_CONSISTENCY_SAMPLE_SIZE = 8192
+
+
+def _cleanup_subprocess_child(c):
+    c.close()
+
+
+def _consistency_child(cache, worker_idx):
+    for i in range(_CONSISTENCY_N_SAMPLES_PER_WORKER):
+        sample_idx = worker_idx * _CONSISTENCY_N_SAMPLES_PER_WORKER + i
+        data = np.array([sample_idx] * _CONSISTENCY_SAMPLE_SIZE, dtype=np.int32)
+        cache.put(sample_idx, data)
+
 
 def test_pickable():
     with tempfile.TemporaryDirectory() as d:
@@ -35,12 +49,9 @@ def test_cleanup():
 
 
 def test_cleanup_subprocess():
-    def child(c):
-        c.close()
-
     with tempfile.TemporaryDirectory() as d:
         cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
-        p = multiprocessing.Process(target=child, args=(cache,))
+        p = multiprocessing.Process(target=_cleanup_subprocess_child, args=(cache,))
         p.start()
         p.join()
 
@@ -60,21 +71,13 @@ def test_multiprocess_consistency():
     # 32 worker processes simultaneously create such data and insert them into
     # a single cache, and we check if the data can be correctly recovered.
     n_workers = 32
-    n_samples_per_worker = 1024
-    sample_size = 8192
-
-    def child(cache, worker_idx):
-        for i in range(n_samples_per_worker):
-            sample_idx = worker_idx * n_samples_per_worker + i
-            data = np.array([sample_idx] * sample_size, dtype=np.int32)
-            cache.put(sample_idx, data)
 
     with tempfile.TemporaryDirectory() as d:
-        with MultiprocessFileCache(n_samples_per_worker * n_workers,
+        with MultiprocessFileCache(_CONSISTENCY_N_SAMPLES_PER_WORKER * n_workers,
                                    dir=d, do_pickle=True) as cache:
 
             # Add tons of data into the cache in parallel
-            ps = [multiprocessing.Process(target=child, args=(cache, worker_idx))  # NOQA
+            ps = [multiprocessing.Process(target=_consistency_child, args=(cache, worker_idx))  # NOQA
                   for worker_idx in range(n_workers)]
             for p in ps:
                 p.start()
@@ -82,9 +85,9 @@ def test_multiprocess_consistency():
                 p.join()
 
             # Get each sample from the cache and check the content
-            for sample_idx in range(n_workers * n_samples_per_worker):
+            for sample_idx in range(n_workers * _CONSISTENCY_N_SAMPLES_PER_WORKER):
                 data = cache.get(sample_idx)
-                expected = np.array([sample_idx] * sample_size, dtype=np.int32)
+                expected = np.array([sample_idx] * _CONSISTENCY_SAMPLE_SIZE, dtype=np.int32)
                 assert (data == expected).all()
 
 
@@ -108,16 +111,17 @@ def test_preservation_interoperability():
         cache2.close()
 
 
+def _preserve_error_subprocess_child(c, pipe):
+    try:
+        c.preserve('preserved')
+    except Exception as e:
+        pipe.send(pickle.dumps(e))
+    finally:
+        pipe.close()
+
+
 def test_preserve_error_subprocess():
     pipe_recv, pipe_send = multiprocessing.Pipe(False)
-
-    def child(c, pipe):
-        try:
-            c.preserve('preserved')
-        except Exception as e:
-            pipe.send(pickle.dumps(e))
-        finally:
-            pipe.close()
 
     with tempfile.TemporaryDirectory() as d:
         cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
@@ -126,7 +130,7 @@ def test_preserve_error_subprocess():
             cache.put(i, str(i))
 
         # Run preservation in the subprocess
-        p = multiprocessing.Process(target=child, args=(cache, pipe_send))
+        p = multiprocessing.Process(target=_preserve_error_subprocess_child, args=(cache, pipe_send))
         p.start()
         p.join()
         cache.close()
@@ -144,21 +148,22 @@ def test_preload_error_not_found():
         cache.close()
 
 
+def _preload_error_subprocess_child(c, pipe):
+    try:
+        c.preload('preserved')
+    except Exception as e:
+        pipe.send(pickle.dumps(e))
+    finally:
+        pipe.close()
+
+
 def test_preload_error_subprocess():
     pipe_recv, pipe_send = multiprocessing.Pipe(False)
-
-    def child(c, pipe):
-        try:
-            c.preload('preserved')
-        except Exception as e:
-            pipe.send(pickle.dumps(e))
-        finally:
-            pipe.close()
 
     with tempfile.TemporaryDirectory() as d:
         # Run preload in the subprocess
         cache = MultiprocessFileCache(10, dir=d, do_pickle=True)
-        p = multiprocessing.Process(target=child, args=(cache, pipe_send))
+        p = multiprocessing.Process(target=_preload_error_subprocess_child, args=(cache, pipe_send))
         p.start()
         p.join()
         cache.close()

--- a/tests/v2_tests/test_fs.py
+++ b/tests/v2_tests/test_fs.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 
 import pytest
-from moto import mock_aws
+from moto import mock_aws, server
 from parameterized import parameterized
 
 from pfio.testing import ZipForTest, randstring
@@ -173,8 +173,8 @@ def test_seekeable_read(target):
 
 
 class DummyLoader:
-    def __init__(self, dirname, content):
-        self.s3 = from_url(dirname)
+    def __init__(self, dirname, content, kwargs):
+        self.s3 = from_url(dirname, **kwargs)
         self.content = content
 
     def __call__(self):
@@ -185,22 +185,31 @@ class DummyLoader:
             assert self.content == fp.read()
 
 
-@mock_aws
-def test_recreate():
+@pytest.mark.parametrize("mp_start_method", ["fork", "forkserver"])
+def test_recreate(mp_start_method):
     content = b'deadbeef'
-    # TODO: test with hdfs?
-    with gen_fs("s3") as fs:
-        with fs.open('file', 'wb') as fp:
-            fp.write(content)
+    address = "127.0.0.1"
+    moto_server = server.ThreadedMotoServer(ip_address=address, port=0)
+    moto_server.start()
+    try:
+        port = moto_server._server.port
+        kwargs = {
+            "endpoint": f"http://{address}:{port}",
+            "aws_access_key_id": "",
+            "aws_secret_access_key": "",
+        }
 
-    dirname = "s3://test-dummy-bucket/"
+        with S3("test-dummy-bucket", create_bucket=True, **kwargs) as fs:
+            with fs.open('file', 'wb') as fp:
+                fp.write(content)
 
-    # With forkserver set, it hangs
-    # mp.set_start_method('forkserver', force=True)
+        dirname = "s3://test-dummy-bucket/"
+        loader = DummyLoader(dirname, content, kwargs)
 
-    loader = DummyLoader(dirname, content)
-
-    p = mp.Process(target=loader)
-    p.start()
-    p.join(timeout=1)
-    assert p.exitcode == 0
+        mp_ctx = mp.get_context(mp_start_method)
+        p = mp_ctx.Process(target=loader)
+        p.start()
+        p.join(timeout=5)
+        assert p.exitcode == 0
+    finally:
+        moto_server.stop()

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -6,7 +6,7 @@ import pickle
 import tempfile
 
 import pytest
-from moto import mock_aws
+from moto import mock_aws, server
 
 from pfio.v2 import S3, from_url, open_url
 from pfio.v2.s3 import _ObjectReader
@@ -140,32 +140,49 @@ def test_empty_file(s3_fixture):
             assert len(f.read()) == 0
 
 
-def test_s3_fork(s3_fixture):
-    with from_url('s3://test-bucket/base',
-                  **s3_fixture.aws_kwargs) as s3:
+def _s3_fork_child_read(s3):
+    with s3.open('foo.txt', 'r') as fp:
+        assert fp.read()
 
-        with s3.open('foo.txt', 'w') as fp:
-            fp.write('bar')
-            assert not fp.closed
 
-        def f(s3):
-            with s3.open('foo.txt', 'r') as fp:
-                assert fp.read()
+def _s3_fork_child_new_s3(kwargs):
+    with S3(bucket='test-bucket', **kwargs) as s4:
+        with s4.open('base/foo.txt', 'r') as fp:
+            assert fp.read()
 
-        p = mp.Process(target=f, args=(s3,))
-        p.start()
-        p.join()
-        assert p.exitcode == 0
 
-        def g(s3):
-            with S3(bucket='test-bucket', **s3_fixture.aws_kwargs) as s4:
-                with s4.open('base/foo.txt', 'r') as fp:
-                    assert fp.read()
+@pytest.mark.parametrize("mp_start_method", ["fork", "forkserver"])
+def test_s3_fork(mp_start_method):
+    address = "127.0.0.1"
+    moto_server = server.ThreadedMotoServer(ip_address=address, port=0)
+    moto_server.start()
+    try:
+        port = moto_server._server.port
+        kwargs = {
+            "endpoint": f"http://{address}:{port}",
+            "aws_access_key_id": "",
+            "aws_secret_access_key": "",
+        }
 
-        p = mp.Process(target=g, args=(s3,))
-        p.start()
-        p.join()
-        assert p.exitcode == 0
+        with from_url('s3://test-bucket/base',
+                      create_bucket=True, **kwargs) as s3:
+            with s3.open('foo.txt', 'w') as fp:
+                fp.write('bar')
+                assert not fp.closed
+
+        with from_url('s3://test-bucket/base', **kwargs) as s3:
+            mp_ctx = mp.get_context(mp_start_method)
+            p = mp_ctx.Process(target=_s3_fork_child_read, args=(s3,))
+            p.start()
+            p.join()
+            assert p.exitcode == 0
+
+            p = mp_ctx.Process(target=_s3_fork_child_new_s3, args=(kwargs,))
+            p.start()
+            p.join()
+            assert p.exitcode == 0
+    finally:
+        moto_server.stop()
 
 
 def test_s3_mpu(s3_fixture):

--- a/tests/v2_tests/test_zip.py
+++ b/tests/v2_tests/test_zip.py
@@ -19,6 +19,14 @@ from pfio.testing import ZipForTest, make_random_str, make_zip
 from pfio.v2 import ZipFileStat, from_url, local
 from pfio.v2.zip import Zip
 
+
+def _zip_read_worker(z, testfile_name, barrier):
+    # accessing the shared container is supported by reset
+    with z.open(testfile_name) as f:
+        barrier.wait()
+        assert f.read()
+
+
 ZIP_TEST_FILENAME_LIST = {
     "dir_name1": "testdir1",
     "dir_name2": "testdir2",
@@ -587,28 +595,27 @@ class TestZipWithLargeData(unittest.TestCase):
         self.zipdir.cleanup()
 
     def test_read_multi_processes(self):
-        barrier = multiprocessing.Barrier(2)
         with local.open_zip(
                 os.path.abspath(self.zip_file_path)) as z:
             with z.open(self.testfile_name) as f:
                 f.read()
 
-            def func():
-                # accessing the shared container is supported by reset
-                with z.open(self.testfile_name) as f:
-                    barrier.wait()
-                    assert f.read()
+            # Use Manager().Barrier() so the barrier can be shared
+            # across processes regardless of start method (fork or forkserver).
+            with multiprocessing.Manager() as manager:
+                barrier = manager.Barrier(2)
+                p1 = multiprocessing.Process(
+                    target=_zip_read_worker, args=(z, self.testfile_name, barrier))
+                p2 = multiprocessing.Process(
+                    target=_zip_read_worker, args=(z, self.testfile_name, barrier))
+                p1.start()
+                p2.start()
 
-            p1 = multiprocessing.Process(target=func)
-            p2 = multiprocessing.Process(target=func)
-            p1.start()
-            p2.start()
+                p1.join(timeout=10)
+                p2.join(timeout=10)
 
-            p1.join(timeout=3)
-            p2.join(timeout=3)
-
-            self.assertEqual(p1.exitcode, 0)
-            self.assertEqual(p2.exitcode, 0)
+                self.assertEqual(p1.exitcode, 0)
+                self.assertEqual(p2.exitcode, 0)
 
 
 NO_DIRECTORY_FILENAME_LIST = {


### PR DESCRIPTION
## Why

In Python 3.14, the default behavior of the `fork()` function in the `multiprocessing` module was changed to `forkserver` even on POSIX systems.

This change caused `mock_aws` monkeypatching to stop being inherited by child processes, resulting in test failures when using `mock_aws`. Additionally, because `forkserver` serializes functions using pickle, any functions that need to be patched must also be converted to module-level functions rather than closures.

## Changes

- Instead of using `mock_aws`, we now start a server using moto's `ThreadedMotoServer` on 127.0.0.1 for testing. This makes the test environment independent of fork behavior
- We remove nested function calls and modify functions to be module-level, ensuring they fork correctly
- We add testing for both `fork` and `forkserver` modes of fork behavior

## Effect

N/A

## Related issues

- #372 