### PR TITLE
fix: s3: isdir()

### DIFF
--- a/pfio/v2/s3.py
+++ b/pfio/v2/s3.py
@@ -618,14 +618,11 @@ class S3(FS):
 
             res = self.client.list_objects_v2(
                 Bucket=self.bucket,
-                Prefix=key,
+                Prefix=f"{key}/",
                 Delimiter="/",
                 MaxKeys=1,
             )
-            for common_prefix in res.get('CommonPrefixes', []):
-                if common_prefix['Prefix'] == key + "/":
-                    return True
-            return False
+            return bool(res.get('Contents') or res.get('CommonPrefixes'))
 
     def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
         '''Does nothing

--- a/tests/v2_tests/test_s3.py
+++ b/tests/v2_tests/test_s3.py
@@ -85,6 +85,29 @@ def test_s3_files(s3_fixture):
         assert not s3.isdir("/bas")
 
 
+def test_s3_isdir_prefix_collision(s3_fixture):
+    # Regression test: abc is a string prefix of abcde, so Prefix="abc" in
+    # list_objects_v2 would also match abcde/bar.txt. The fix uses Prefix="abc/"
+    # to ensure only keys inside abc/ are considered.
+    with S3(s3_fixture.bucket, create_bucket=False) as s3:
+        touch(s3, 'abc/foo.txt', 'hello')
+        touch(s3, 'abcde/bar.txt', 'world')
+
+        assert s3.isdir('abc')
+        assert s3.isdir('abcde')
+        assert not s3.isdir('abcd')
+        assert not s3.isdir('ab')
+        assert not s3.isdir('abcde/bar.txt')
+
+    # Also verify: when only abcde/ exists, abc should NOT be a directory
+    with S3(s3_fixture.bucket, create_bucket=False) as s32:
+        touch(s32, 'xyz/abcde/bar.txt', 'world')
+
+        assert not s32.isdir('xyz/abc')
+        assert s32.isdir('xyz/abcde')
+        assert not s32.isdir('xyz/abcd')
+
+
 def test_s3_init_with_timeouts(s3_fixture):
     with from_url('s3://test-bucket/base',
                   connect_timeout=300,


### PR DESCRIPTION
Fix a bug in S3 where it incorrectly identified simple prefix matches as directories.

When a partially matching key already exists as shown below, and MaxKeys=1 is set to 1, `bus/` would be retrieved first, but since it's not `bush`, the operation would fail, resulting in the directory being incorrectly identified as non-existent.

- `bus/engine.txt`
- `bush/kusamura.txt`

The solution is to prepend a `/` suffix when performing the List operation and determine existence based on whether a Common Prefix or Contents exist. If at least one exists, we can safely consider this prefix as a directory presence, and the presence of the `/` suffix prevents simple prefix matching from failing.

## Related Issue(PR)s

closes #379

## Effect

This is a just bug fix.